### PR TITLE
Add PortfolioDefaults entity to MongoDB

### DIFF
--- a/apps/augury-backend/src/config/enums/PortfolioColor.ts
+++ b/apps/augury-backend/src/config/enums/PortfolioColor.ts
@@ -1,0 +1,7 @@
+export enum PortfolioColor {
+  WHITE = 'white',
+  RED = 'red',
+  GREEN = 'green',
+  BLUE = 'blue',
+  YELLOW = 'yellow',
+}

--- a/apps/augury-backend/src/config/enums/PortfolioRisk.ts
+++ b/apps/augury-backend/src/config/enums/PortfolioRisk.ts
@@ -1,0 +1,5 @@
+export enum PortfolioRisk {
+  CONSERVATIVE = 'conservative',
+  MODERATE = 'moderate',
+  AGGRESSIVE = 'aggressive',
+}

--- a/apps/augury-backend/src/config/enums/Severity.ts
+++ b/apps/augury-backend/src/config/enums/Severity.ts
@@ -1,0 +1,6 @@
+export enum Severity {
+  LOW,
+  MED,
+  HIGH,
+  SEVERE,
+}

--- a/apps/augury-backend/src/config/interfaces/BuyRecord.ts
+++ b/apps/augury-backend/src/config/interfaces/BuyRecord.ts
@@ -1,7 +1,7 @@
-import { Document, ObjectId } from 'mongoose';
+import { Types } from 'mongoose';
 
-export default interface BuyRecord extends Document {
-  stockId: ObjectId;
+export default interface BuyRecord {
+  stockId: Types.ObjectId;
   shares: number;
   boughtAtPrice: number;
 }

--- a/apps/augury-backend/src/config/interfaces/Portfolio.ts
+++ b/apps/augury-backend/src/config/interfaces/Portfolio.ts
@@ -1,10 +1,5 @@
 import { Document } from 'mongoose';
-
-export enum PortfolioRisk {
-  CONSERVATIVE = 'conservative',
-  MODERATE = 'moderate',
-  AGGRESSIVE = 'aggressive',
-}
+import { PortfolioRisk } from '../enums/PortfolioRisk';
 
 export default interface Portfolio extends Document {
   name: string;

--- a/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
@@ -1,0 +1,6 @@
+import { ObjectId } from 'mongoose';
+import Portfolio from './Portfolio';
+
+export default interface PortfolioDefault extends Portfolio {
+  userId: ObjectId;
+}

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -1,15 +1,8 @@
 import { Document, ObjectId } from 'mongoose';
-
-export enum Color {
-  WHITE = 'white',
-  RED = 'red',
-  GREEN = 'green',
-  BLUE = 'blue',
-  YELLOW = 'yellow',
-}
+import { PortfolioColor } from '../enums/PortfolioColor';
 
 export default interface PortfolioGroup extends Document {
   name: string;
-  color: Color;
+  color: PortfolioColor;
   userId: ObjectId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -1,8 +1,8 @@
-import { Document, ObjectId } from 'mongoose';
+import { Types } from 'mongoose';
 import { PortfolioColor } from '../enums/PortfolioColor';
 
-export default interface PortfolioGroup extends Document {
+export default interface PortfolioGroup {
   name: string;
   color: PortfolioColor;
-  userId: ObjectId;
+  userId: Types.ObjectId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
@@ -1,6 +1,6 @@
-import { Document, ObjectId } from 'mongoose';
+import { Types } from 'mongoose';
 
-export default interface PortfolioGroupRelation extends Document {
-  portfolioId: ObjectId;
-  portfolioGroupId: ObjectId;
+export default interface PortfolioGroupRelation {
+  portfolioId: Types.ObjectId;
+  portfolioGroupId: Types.ObjectId;
 }

--- a/apps/augury-backend/src/config/interfaces/Session.ts
+++ b/apps/augury-backend/src/config/interfaces/Session.ts
@@ -1,7 +1,7 @@
-import { Document, ObjectId } from 'mongoose';
+import { Types } from 'mongoose';
 
-export default interface Session extends Document {
-  userId: ObjectId;
+export default interface Session {
+  userId: Types.ObjectId;
   token: string;
   created: number;
   expires: number;

--- a/apps/augury-backend/src/config/interfaces/Stock.ts
+++ b/apps/augury-backend/src/config/interfaces/Stock.ts
@@ -1,6 +1,6 @@
-import { Document, ObjectId } from 'mongoose';
+import { Types } from 'mongoose';
 
-export default interface Stock extends Document {
-  portfolioId: ObjectId;
+export default interface Stock {
+  portfolioId: Types.ObjectId;
   symbol: string;
 }

--- a/apps/augury-backend/src/config/interfaces/User.ts
+++ b/apps/augury-backend/src/config/interfaces/User.ts
@@ -1,6 +1,4 @@
-import { Document } from 'mongoose';
-
-export default interface User extends Document {
+export default interface User {
   email: string;
   password: string;
   firstName?: string;

--- a/apps/augury-backend/src/config/schemas/BuyRecord.ts
+++ b/apps/augury-backend/src/config/schemas/BuyRecord.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import BuyRecord from '../interfaces/BuyRecord';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<BuyRecord>({
   stockId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,

--- a/apps/augury-backend/src/config/schemas/Portfolio.ts
+++ b/apps/augury-backend/src/config/schemas/Portfolio.ts
@@ -1,6 +1,8 @@
 import mongoose from 'mongoose';
+import Portfolio from '../interfaces/Portfolio';
+import { PortfolioRisk } from '../enums/PortfolioRisk';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<Portfolio>({
   name: {
     type: String,
     required: true,
@@ -8,8 +10,8 @@ const schema = new mongoose.Schema({
 
   risk: {
     type: String,
-    enum: ['conservative', 'moderate', 'aggressive'], // Enum definition
-    default: 'conservative', // Default value for status
+    enum: Object.values(PortfolioRisk), // Enum definition
+    default: PortfolioRisk.CONSERVATIVE, // Default value for status
     required: true,
   },
 });

--- a/apps/augury-backend/src/config/schemas/PortfolioDefault.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioDefault.ts
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+import PortfolioDefault from '../interfaces/PortfolioDefault';
+import { PortfolioRisk } from '../enums/PortfolioRisk';
+
+const schema = new mongoose.Schema<PortfolioDefault>({
+  userId: {
+    type: mongoose.Schema.ObjectId,
+    required: true,
+    ref: 'User',
+  },
+
+  name: {
+    type: String,
+    required: true,
+  },
+
+  risk: {
+    type: String,
+    enum: Object.values(PortfolioRisk), // Enum definition
+    default: PortfolioRisk.CONSERVATIVE, // Default value for status
+    required: true,
+  },
+});
+
+const PortfolioDefaultSchema = mongoose.model('Portfolio', schema);
+
+export default PortfolioDefaultSchema;

--- a/apps/augury-backend/src/config/schemas/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioGroup.ts
@@ -1,6 +1,8 @@
 import mongoose from 'mongoose';
+import PortfolioGroup from '../interfaces/PortfolioGroup';
+import { PortfolioColor } from '../enums/PortfolioColor';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<PortfolioGroup>({
   name: {
     type: String,
     required: true,
@@ -8,8 +10,8 @@ const schema = new mongoose.Schema({
 
   color: {
     type: String,
-    enum: ['white', 'red', 'green', 'blue', 'yellow'], // Enum definition
-    default: 'white', // Default value for status
+    enum: Object.values(PortfolioColor), // Enum definition
+    default: PortfolioColor.WHITE, // Default value for status
     required: true,
   },
 

--- a/apps/augury-backend/src/config/schemas/PortfolioGroupRelation.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioGroupRelation.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import PortfolioGroupRelation from '../interfaces/PortfolioGroupRelation';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<PortfolioGroupRelation>({
   portfolioId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,

--- a/apps/augury-backend/src/config/schemas/Session.ts
+++ b/apps/augury-backend/src/config/schemas/Session.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import Session from '../interfaces/Session';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<Session>({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,

--- a/apps/augury-backend/src/config/schemas/Stock.ts
+++ b/apps/augury-backend/src/config/schemas/Stock.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import Stock from '../interfaces/Stock';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<Stock>({
   portfolioId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,

--- a/apps/augury-backend/src/config/schemas/User.ts
+++ b/apps/augury-backend/src/config/schemas/User.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import User from '../interfaces/User';
 
-const schema = new mongoose.Schema({
+const schema = new mongoose.Schema<User>({
   email: {
     type: String,
     required: true,

--- a/apps/augury-backend/src/errors/ApiError.ts
+++ b/apps/augury-backend/src/errors/ApiError.ts
@@ -1,10 +1,6 @@
 import { ApplicationError } from './ApplicationError';
-export enum Severity {
-  LOW,
-  MED,
-  HIGH,
-  SEVERE,
-}
+import { Severity } from '../config/enums/Severity';
+
 export default class ApiError extends ApplicationError {
   private readonly severity: Severity;
 


### PR DESCRIPTION
This is a quick PR based on the contents and research found in #16 but wasn't merged in. Additionally, it contains the new schema  and interface for `PortfolioDefaults`.
# Changes made
- Created a new Schema for `PortfolioDefault` that extends Portfolio and includes a `userId`
- Removed `extends Document` from all interfaces, as Mongoose unions the types for us.
- Applied typing to schemas to maintain structure more easily (Apply any changes to schemas **first** for a better experience)
- Refactored enums from Schemas & Error handling into `/src/config/enums/*.ts`