### PR TITLE
Update Routes and simplify PortfolioDefaults

### DIFF
--- a/apps/augury-backend/src/config/interfaces/Portfolio.ts
+++ b/apps/augury-backend/src/config/interfaces/Portfolio.ts
@@ -1,12 +1,12 @@
-import PortfolioRisk from '../enums/PortfolioRisk';
+// import PortfolioRisk from '../enums/PortfolioRisk';
 import Sectors from '../enums/Sectors';
 import Identifiable from './Identifiable';
 
 export default interface Portfolio extends Identifiable {
   name: string; // Portfolio name
-  risk?: PortfolioRisk; // Optional risk if `useCustomRisk` is true
-  useCustomRisk: boolean; // If true, indicates custom risk settings are used
-  customRiskPercentage1?: number; // First custom percentage value if using custom risk
-  customRiskPercentage2?: number; // Second custom percentage value if using custom risk
-  sectorTags?: Sectors[]; // Array of sector tags
+  // risk?: PortfolioRisk; // Optional risk if `useCustomRisk` is true
+  // useCustomRisk: boolean; // If true, indicates custom risk settings are used
+  riskPercentage1?: number;
+  riskPercentage2?: number;
+  sectorTags?: Sectors[];
 }

--- a/apps/augury-backend/src/config/schemas/PortfolioDefaultSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioDefaultSchema.ts
@@ -1,20 +1,20 @@
 import mongoose from 'mongoose';
 import PortfolioDefault from '../interfaces/PortfolioDefault';
-import PortfolioRisk from '../enums/PortfolioRisk';
+// import PortfolioRisk from '../enums/PortfolioRisk';
 import stripAndFormatIds from '../utils/stripAndFormatIds';
 
 const schema = new mongoose.Schema<PortfolioDefault>({
   userId: { type: mongoose.Schema.Types.ObjectId }, // Reference to the user these defaults are for
   name: { type: String, required: true }, // Portfolio name
-  risk: {
-    // Optional risk level
-    type: String,
-    enum: Object.values(PortfolioRisk), // Enum definition
-    // default: PortfolioRisk.CONSERVATIVE, // Default value for status
-  },
-  useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
-  customRiskPercentage1: { type: Number },
-  customRiskPercentage2: { type: Number },
+  // risk: {
+  //   // Optional risk level
+  //   type: String,
+  //   enum: Object.values(PortfolioRisk), // Enum definition
+  //   // default: PortfolioRisk.CONSERVATIVE, // Default value for status
+  // },
+  // useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
+  riskPercentage1: { type: Number },
+  riskPercentage2: { type: Number },
   sectorTags: [String], // Would use custom validation but it's weird to enforce. Will validate through business logic
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware

--- a/apps/augury-backend/src/config/schemas/PortfolioSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioSchema.ts
@@ -1,19 +1,19 @@
 import mongoose from 'mongoose';
 import Portfolio from '../interfaces/Portfolio';
-import PortfolioRisk from '../enums/PortfolioRisk';
+// import PortfolioRisk from '../enums/PortfolioRisk';
 import stripAndFormatIds from '../utils/stripAndFormatIds';
 
 const schema = new mongoose.Schema<Portfolio>({
   name: { type: String, required: true }, // Portfolio name
-  risk: {
-    // Optional risk level
-    type: String,
-    enum: Object.values(PortfolioRisk), // Enum definition
-    // default: PortfolioRisk.CONSERVATIVE, // Default value for status
-  },
-  useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
-  customRiskPercentage1: { type: Number },
-  customRiskPercentage2: { type: Number },
+  // risk: {
+  //   // Optional risk level
+  //   type: String,
+  //   enum: Object.values(PortfolioRisk), // Enum definition
+  //   // default: PortfolioRisk.CONSERVATIVE, // Default value for status
+  // },
+  // useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
+  riskPercentage1: { type: Number },
+  riskPercentage2: { type: Number },
   sectorTags: [String], // Would use custom validation but it's weird to enforce. Will validate through business logic
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware

--- a/apps/augury-backend/src/config/utils/validation.ts
+++ b/apps/augury-backend/src/config/utils/validation.ts
@@ -1,5 +1,5 @@
 import ClientError from '../../errors/ClientError';
-import PortfolioRisk from '../enums/PortfolioRisk';
+// import PortfolioRisk from '../enums/PortfolioRisk';
 import Sectors from '../enums/Sectors';
 import StatusCode from '../enums/StatusCode';
 import Portfolio from '../interfaces/Portfolio';
@@ -57,18 +57,12 @@ export function assertEnum<T, G>(enumObj: T, value: G, errorMsg: string) {
 export function assertPortfolioDefaultsFormat(defaults: Portfolio) {
   assertExists(defaults, 'Invalid defaults provided');
   assertExists(defaults.name, 'Invalid portfolio name provided');
-  if (defaults.useCustomRisk) {
-    assertExists(
-      defaults.customRiskPercentage1,
-      'Invalid customRiskPercentage1 provided'
-    );
-    assertExists(
-      defaults.customRiskPercentage2,
-      'Invalid customRiskPercentage2 provided'
-    );
-  } else {
-    assertEnum(PortfolioRisk, defaults.risk, 'Invalid risk provided');
-  }
+  // if (defaults.useCustomRisk) {
+  assertExists(defaults.riskPercentage1, 'Invalid riskPercentage1 provided');
+  assertExists(defaults.riskPercentage2, 'Invalid riskPercentage2 provided');
+  // } else {
+  //   assertEnum(PortfolioRisk, defaults.risk, 'Invalid risk provided');
+  // }
   if (Array.isArray(defaults.sectorTags)) {
     for (const tag of defaults.sectorTags) {
       assertEnum(Sectors, tag, 'Invalid sector tag provided');

--- a/apps/augury-backend/src/config/utils/validation.ts
+++ b/apps/augury-backend/src/config/utils/validation.ts
@@ -11,7 +11,7 @@ import Portfolio from '../interfaces/Portfolio';
  * @throws `ClientError` if parameter is `null` or `undefined`
  */
 export function assertExists<T>(param: T, errorMsg: string) {
-  if (!(param != null)) {
+  if (!(param != null) || (typeof param === 'string' && !param)) {
     throw new ClientError(errorMsg, StatusCode.BAD_REQUEST);
   }
 }

--- a/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
@@ -11,8 +11,12 @@ import User from '../../config/interfaces/User';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
 import ApiError from '../../errors/ApiError';
 import Sectors from '../../config/enums/Sectors';
-import PortfolioRisk from '../../config/enums/PortfolioRisk';
+// import PortfolioRisk from '../../config/enums/PortfolioRisk';
 import Identifiable from '../../config/interfaces/Identifiable';
+
+type PortfolioDefaultResponse = {
+  defaults: PortfolioDefault;
+};
 
 /**
  * Retrieves a User's portfolio defaults from the database by user ID
@@ -23,7 +27,7 @@ import Identifiable from '../../config/interfaces/Identifiable';
  */
 const getPortfolioDefaults = async (
   req: Request<Identifiable>,
-  res: Response
+  res: Response<PortfolioDefaultResponse>
 ) => {
   const { id: userId } = req.params;
   // Assert the request format was valid
@@ -53,7 +57,7 @@ const getPortfolioDefaults = async (
  */
 const createPortfolioDefaults = async (
   req: Request<unknown, unknown, PortfolioDefault>,
-  res: Response
+  res: Response<PortfolioDefaultResponse>
 ) => {
   // Assert the request format was valid
   assertPortfolioDefaultsFormat(req.body);
@@ -61,20 +65,20 @@ const createPortfolioDefaults = async (
   const {
     userId,
     name,
-    risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   }: PortfolioDefault = req.body;
 
   const newDefaults: PortfolioDefault = {
     userId,
     name,
-    risk: useCustomRisk ? undefined : risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk: useCustomRisk ? undefined : risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   };
 
@@ -104,22 +108,22 @@ const createPortfolioDefaults = async (
  */
 const updatePortfolioDefaults = async (
   req: Request<unknown, unknown, PortfolioDefault>,
-  res: Response
+  res: Response<PortfolioDefaultResponse>
 ) => {
   const {
     userId,
     name,
-    risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   }: PortfolioDefault = req.body;
   // Assert the request format was valid
   assertExists(userId, 'Invalid ID provided');
-  if (risk != null) {
-    assertEnum(PortfolioRisk, risk, 'Invalid risk provided');
-  }
+  // if (risk != null) {
+  //   assertEnum(PortfolioRisk, risk, 'Invalid risk provided');
+  // }
   if (Array.isArray(sectorTags)) {
     for (const tag of sectorTags) {
       assertEnum(Sectors, tag, 'Invalid sector tag provided');
@@ -129,10 +133,10 @@ const updatePortfolioDefaults = async (
   const newDefaults: PortfolioDefault = {
     userId,
     name,
-    risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   };
 
@@ -160,7 +164,7 @@ const updatePortfolioDefaults = async (
  */
 const deletePortfolioDefaults = async (
   req: Request<unknown, unknown, User>,
-  res: Response
+  res: Response<PortfolioDefaultResponse>
 ): Promise<void> => {
   const { id: userId } = req.body;
   // Assert the request format was valid
@@ -170,7 +174,7 @@ const deletePortfolioDefaults = async (
 
   if (response) {
     // send the user back after model runs logic
-    res.status(StatusCode.OK).send({ user: response });
+    res.status(StatusCode.OK).send({ defaults: response });
   } else {
     // we throw an API error since this means something errored out with our server end
     throw new ApiError(

--- a/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
@@ -12,19 +12,20 @@ import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
 import ApiError from '../../errors/ApiError';
 import Sectors from '../../config/enums/Sectors';
 import PortfolioRisk from '../../config/enums/PortfolioRisk';
+import Identifiable from '../../config/interfaces/Identifiable';
 
 /**
  * Retrieves a User's portfolio defaults from the database by user ID
- * @param req Request with body containing a string `id` field
+ * @param req Request with URL parameter containing an `id`
  * @param res Response with portfolio defaults
  * @throws `ClientError` if request is invalid
  * @throws `ApiError` if unable to retrieve defaults
  */
 const getPortfolioDefaults = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable>,
   res: Response
 ) => {
-  const { id: userId } = req.body;
+  const { id: userId } = req.params;
   // Assert the request format was valid
   assertExists(userId, 'Invalid ID provided');
   // Retrieve data from the DB using request parameters/data

--- a/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioDefaultController.ts
@@ -7,7 +7,7 @@ import {
 import PortfolioDefaultsModel from '../../models/auth/PortfolioDefaultModel';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
-import User from '../../config/interfaces/User';
+// import User from '../../config/interfaces/User';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
 import ApiError from '../../errors/ApiError';
 import Sectors from '../../config/enums/Sectors';
@@ -101,17 +101,17 @@ const createPortfolioDefaults = async (
 
 /**
  * Updates portfolio defaults for a user based on the passed request body
- * @param req Request with `PortfolioDefault` options (e.g. userId, risk)
+ * @param req Request with URL parameter for ID and a `PortfolioDefault` body (e.g. name, sectors)
  * @param res Response with updated portfolio defaults
- * @throws `ClientError` if request is invalid (missing `userId`)
+ * @throws `ClientError` if request is invalid (e.g. a bad sector tag)
  * @throws `ApiError` if unable to create defaults
  */
 const updatePortfolioDefaults = async (
-  req: Request<unknown, unknown, PortfolioDefault>,
+  req: Request<Identifiable, unknown, PortfolioDefault>,
   res: Response<PortfolioDefaultResponse>
 ) => {
+  const { id: userId } = req.params;
   const {
-    userId,
     name,
     // risk,
     // useCustomRisk,
@@ -163,10 +163,10 @@ const updatePortfolioDefaults = async (
  * @param res Deleted user's information
  */
 const deletePortfolioDefaults = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable>,
   res: Response<PortfolioDefaultResponse>
 ): Promise<void> => {
-  const { id: userId } = req.body;
+  const { id: userId } = req.params;
   // Assert the request format was valid
   assertExists(userId, 'Invalid ID provided');
   // Delete the User from the DB

--- a/apps/augury-backend/src/controllers/auth/UserController.ts
+++ b/apps/augury-backend/src/controllers/auth/UserController.ts
@@ -253,20 +253,20 @@ const onboardNewUser = async (
   assertPortfolioDefaultsFormat(defaults);
   const {
     name,
-    risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   }: Portfolio = defaults;
 
   const newDefaults: PortfolioDefault = {
     userId,
     name,
-    risk: useCustomRisk ? undefined : risk,
-    useCustomRisk,
-    customRiskPercentage1,
-    customRiskPercentage2,
+    // risk: useCustomRisk ? undefined : risk,
+    // useCustomRisk,
+    riskPercentage1,
+    riskPercentage2,
     sectorTags,
   };
   const [defaultsResponse, updateUserResponse] = await Promise.all([

--- a/apps/augury-backend/src/controllers/auth/UserController.ts
+++ b/apps/augury-backend/src/controllers/auth/UserController.ts
@@ -131,12 +131,14 @@ const createUser = async (
  * @throws ApiError if unable to update user
  */
 const updateUser = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable, unknown, User>,
   res: Response<UserReponse>
 ): Promise<void> => {
-  const { id: userId, email, googleId, firstName, lastName } = req.body;
+  // Get id from URLparams, rest of the user data from body
+  const { id } = req.params;
+  const { email, googleId, firstName, lastName } = req.body;
   // Assert the request format was valid
-  assertExists(userId, 'Invalid ID provided!');
+  assertExists(id, 'Invalid ID provided!');
 
   // Update the User in the DB using request parameters/data
   const user: Partial<User> = {
@@ -145,7 +147,7 @@ const updateUser = async (
     firstName: firstName || undefined,
     lastName: lastName || undefined,
   };
-  const response = await UserModel.updateUser(userId, user);
+  const response = await UserModel.updateUser(id, user);
 
   if (response) {
     // send the user back after model runs logic
@@ -168,19 +170,20 @@ const updateUser = async (
  * @throws ApiError if unable to update user
  */
 const updateUserBalance = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable, unknown, User>,
   res: Response<UserReponse>
 ): Promise<void> => {
-  const { id: userId, balance } = req.body;
+  const { id } = req.params;
+  const { balance } = req.body;
   // Assert the request format was valid
-  assertExists(userId, 'Invalid ID provided!');
+  assertExists(id, 'Invalid ID provided!');
   assertNumber(balance, 'Invalid balance provided');
 
   // Update the User in the DB using request parameters/data
   const updatedUserFields: Partial<User> = {
     balance,
   };
-  const response = await UserModel.updateUser(userId, updatedUserFields);
+  const response = await UserModel.updateUser(id, updatedUserFields);
 
   if (response) {
     // send the user back after model runs logic
@@ -202,14 +205,14 @@ const updateUserBalance = async (
  * @param res Deleted user's information
  */
 const deleteUser = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable>,
   res: Response<UserReponse>
 ): Promise<void> => {
-  const { id: userId } = req.body;
+  const { id } = req.params;
   // Assert the request format was valid
-  assertExists(userId, 'Invalid ID provided');
+  assertExists(id, 'Invalid ID provided');
   // Delete the User from the DB
-  const response = await UserModel.deleteUser(userId);
+  const response = await UserModel.deleteUser(id);
 
   if (response) {
     // send the user back after model runs logic

--- a/apps/augury-backend/src/controllers/auth/UserController.ts
+++ b/apps/augury-backend/src/controllers/auth/UserController.ts
@@ -13,6 +13,7 @@ import Severity from '../../config/enums/Severity';
 import Portfolio from '../../config/interfaces/Portfolio';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
 import PortfolioDefaultModel from '../../models/auth/PortfolioDefaultModel';
+import Identifiable from '../../config/interfaces/Identifiable';
 
 type UserReponse = {
   user: User;
@@ -20,16 +21,16 @@ type UserReponse = {
 
 /**
  * Retrieves a User from the database based on their ID
- * @param req Request with body containing a string `id` field
+ * @param req Request with URL parameter containing an `id`
  * @param res Response with user data
  * @throws ClientError if request is invalid
  * @throws ApiError if unable to retrieve user
  */
 const getUser = async (
-  req: Request<unknown, unknown, User>,
+  req: Request<Identifiable>,
   res: Response<UserReponse>
 ): Promise<void> => {
-  const { id: userId } = req.body;
+  const { id: userId } = req.params;
   // Assert the request format was valid
   assertExists(userId, 'Invalid ID provided');
 

--- a/apps/augury-backend/src/main.ts
+++ b/apps/augury-backend/src/main.ts
@@ -36,7 +36,7 @@ app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
 // Application routers that register handlers
 app.use('/user', userRouter);
-app.use('/user/portfolio', portfolioRouter);
+app.use('/portfolio', portfolioRouter);
 
 // API Routes
 app.get('/google/callback', asyncErrorHandler(googleOauthHandler)); // Google Callback route that is used after OAuth redirect

--- a/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
@@ -54,7 +54,8 @@ const updatePortfolioDefaults = async (data: Partial<PortfolioDefault>) => {
   const { userId, ...updateData }: Partial<PortfolioDefault> = data;
   const updatedDefaults = await PortfolioDefaultSchema.findOneAndUpdate(
     { userId },
-    updateData
+    updateData,
+    { new: true }
   );
 
   if (!updatedDefaults) {

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -9,15 +9,14 @@ const portfolioRouter: Router = express.Router();
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
 portfolioRouter
-  .route('/defaults/:id')
-  .get(asyncErrorHandler(PortfolioDefaultController.getPortfolioDefaults));
+  .route('/defaults')
+  .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults));
 
 portfolioRouter
-  .route('/defaults')
+  .route('/defaults/:id')
+  .get(asyncErrorHandler(PortfolioDefaultController.getPortfolioDefaults))
   .put(asyncErrorHandler(PortfolioDefaultController.updatePortfolioDefaults))
-  .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults))
   .delete(
     asyncErrorHandler(PortfolioDefaultController.deletePortfolioDefaults)
   );
-
 export default portfolioRouter;

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -9,8 +9,11 @@ const portfolioRouter: Router = express.Router();
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
 portfolioRouter
+  .route('/defaults/:id')
+  .get(asyncErrorHandler(PortfolioDefaultController.getPortfolioDefaults));
+
+portfolioRouter
   .route('/defaults')
-  .get(asyncErrorHandler(PortfolioDefaultController.getPortfolioDefaults))
   .put(asyncErrorHandler(PortfolioDefaultController.updatePortfolioDefaults))
   .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults))
   .delete(

--- a/apps/augury-backend/src/routes/UserRoutes.ts
+++ b/apps/augury-backend/src/routes/UserRoutes.ts
@@ -8,9 +8,10 @@ const userRouter: Router = express.Router();
 // Uncomment if we want to verify the client's auth token for all routes
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
+userRouter.route('/:id').get(asyncErrorHandler(UserController.getUser));
+
 userRouter
   .route('/')
-  .get(asyncErrorHandler(UserController.getUser))
   .post(asyncErrorHandler(UserController.createUser))
   .put(asyncErrorHandler(UserController.updateUser));
 // .delete(asyncErrorHandler(UserController.deleteUser));

--- a/apps/augury-backend/src/routes/UserRoutes.ts
+++ b/apps/augury-backend/src/routes/UserRoutes.ts
@@ -8,16 +8,16 @@ const userRouter: Router = express.Router();
 // Uncomment if we want to verify the client's auth token for all routes
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
-userRouter.route('/:id').get(asyncErrorHandler(UserController.getUser));
+userRouter.route('/').post(asyncErrorHandler(UserController.createUser));
 
 userRouter
-  .route('/')
-  .post(asyncErrorHandler(UserController.createUser))
+  .route('/:id')
+  .get(asyncErrorHandler(UserController.getUser))
   .put(asyncErrorHandler(UserController.updateUser));
 // .delete(asyncErrorHandler(UserController.deleteUser));
 
 userRouter
-  .route('/balance')
+  .route('/:id/balance')
   .put(asyncErrorHandler(UserController.updateUserBalance));
 
 userRouter

--- a/apps/augury/src/api/portfolio/Portfolio.ts
+++ b/apps/augury/src/api/portfolio/Portfolio.ts
@@ -1,7 +1,7 @@
-import axios from "axios";
-import { CompositionValues } from "../../components/onboarding/OnboardingDefaults";
-import { SERVER_URL } from "../Environments";
-import AuthStoreManager from "../../helpers/AuthStoreManager";
+import axios from 'axios';
+import { CompositionValues } from '../../components/onboarding/OnboardingDefaults';
+import { SERVER_URL } from '../Environments';
+import AuthStoreManager from '../../helpers/AuthStoreManager';
 
 export interface PortfolioDefaultBody {
   balance: string;
@@ -18,12 +18,12 @@ async function updatePortfolioDefaults(reqBody: PortfolioDefaultBody) {
         id: AuthStoreManager.getUserId(),
         balance: Number(reqBody.balance),
         defaults: {
-          name: "default",
-          useCustomRisk: reqBody.risk,
-          customRiskPercentage1: reqBody.composition,
-          customRiskPercentage2: 100 - reqBody.composition,
-          sectorTags: reqBody.sectors
-        }
+          name: 'default',
+          // useCustomRisk: reqBody.risk,
+          riskPercentage1: reqBody.composition,
+          riskPercentage2: 100 - reqBody.composition,
+          sectorTags: reqBody.sectors,
+        },
       },
       {
         headers: {
@@ -36,7 +36,6 @@ async function updatePortfolioDefaults(reqBody: PortfolioDefaultBody) {
       return false;
     }
     return true;
-
   } catch (err) {
     return false;
   }

--- a/apps/augury/src/helpers/format.ts
+++ b/apps/augury/src/helpers/format.ts
@@ -12,10 +12,10 @@ export function parseValues(val: string): string {
 //     id: id,
 //     balance: onboardingData.balance,
 //     defaults: {
-//       useCustomRisk: onboardingData.risk || 'false',
+// //       useCustomRisk: onboardingData.risk || 'false',
 //       name: 'default',
-//       customRiskPercentage1: onboardingData.composition,
-//       customRiskPercentage2: 100 - onboardingData.composition,
+//       riskPercentage1: onboardingData.composition,
+//       riskPercentage2: 100 - onboardingData.composition,
 //       sectorTags: onboardingData.sectors,
 //     },
 //   });


### PR DESCRIPTION
# Changes
This refactors the BE routes to make it more RESTful + allow the front-end to actually call our GET endpoints (since Axios doesn't natively allow us to include a body with our GET requests). This nearly fixes the onboarding procedure but the front-end still needs to correctly store/load the user ID in order to pass it along with the request.
- Moved `/user/portfolio` to `/portfolio` in routes
- Refactored both User routes and `PortfolioDefaults` routes to now use URL Parameters and be more REST-ful.
- Simplified the schema and logic surrounding `PortfolioDefaults` by commenting out risk/`useCustomRisk` logic
- Fixed minor validation bug where it allows an empty string