### PR TITLE
Portfolio Groups Functionality

### DIFF
--- a/apps/augury-backend/src/config/interfaces/BuyRecord.ts
+++ b/apps/augury-backend/src/config/interfaces/BuyRecord.ts
@@ -1,8 +1,8 @@
-import { Types } from 'mongoose';
 import Identifiable from './Identifiable';
+import DocumentId from './DocumentId';
 
 export default interface BuyRecord extends Identifiable {
-  stockId: Types.ObjectId | string;
+  stockId: DocumentId;
   shares: number;
   boughtAtPrice: number;
 }

--- a/apps/augury-backend/src/config/interfaces/DocumentId.ts
+++ b/apps/augury-backend/src/config/interfaces/DocumentId.ts
@@ -1,0 +1,5 @@
+import { Types } from 'mongoose';
+
+type DocumentId = string | Types.ObjectId;
+
+export default DocumentId;

--- a/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
@@ -1,6 +1,6 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Portfolio from './Portfolio';
 
 export default interface PortfolioDefault extends Portfolio {
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -7,3 +7,15 @@ export default interface PortfolioGroup extends Identifiable {
   color: PortfolioColor;
   userId: DocumentId;
 }
+
+export type PortfolioGroupRequestBody = PortfolioGroup & {
+  portfolios?: DocumentId[];
+};
+
+export type PortfolioGroupResponse = {
+  group: PortfolioGroup;
+};
+
+export type PortfolioGroupsResponse = {
+  groups: PortfolioGroup[];
+};

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -1,9 +1,9 @@
-import { Types } from 'mongoose';
 import PortfolioColor from '../enums/PortfolioColor';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface PortfolioGroup extends Identifiable {
   name: string;
   color: PortfolioColor;
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface PortfolioGroupRelation extends Identifiable {
-  portfolioId: Types.ObjectId | string;
-  portfolioGroupId: Types.ObjectId | string;
+  portfolioId: DocumentId;
+  portfolioGroupId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/Session.ts
+++ b/apps/augury-backend/src/config/interfaces/Session.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
 import Identifiable from './Identifiable';
+import DocumentId from './DocumentId';
 
 export default interface Session extends Identifiable {
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
   token: string;
 }

--- a/apps/augury-backend/src/config/interfaces/Stock.ts
+++ b/apps/augury-backend/src/config/interfaces/Stock.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface Stock extends Identifiable {
-  portfolioId: Types.ObjectId | string;
+  portfolioId: DocumentId;
   symbol: string;
 }

--- a/apps/augury-backend/src/config/schemas/PortfolioGroupRelationSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioGroupRelationSchema.ts
@@ -16,6 +16,8 @@ const schema = new mongoose.Schema<PortfolioGroupRelation>({
   },
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware
+// Prevent duplicated relations
+schema.index({ portfolioId: 1, portfolioGroupId: 1 }, { unique: true });
 
 const PortfolioGroupRelationSchema = mongoose.model<PortfolioGroupRelation>(
   'PortfolioGroupRelation',

--- a/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
@@ -1,0 +1,179 @@
+import { Request, Response } from 'express';
+import { assertEnum, assertExists } from '../../config/utils/validation';
+import ApiError from '../../errors/ApiError';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import PortfolioGroupModel from '../../models/auth/PortfolioGroupModel';
+import PortfolioColor from '../../config/enums/PortfolioColor';
+import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
+import Identifiable from '../../config/interfaces/Identifiable';
+import DocumentId from '../../config/interfaces/DocumentId';
+
+type PortfolioGroupRequestBody = PortfolioGroup & {
+  portfolios?: DocumentId[];
+};
+
+/**
+ * Creates a new portfolio group based on the passed request body
+ * @param req Request with `PortfolioGroup` fields
+ * @param res Response with new portfolio group
+ * @throws `ClientError` if request is invalid
+ * @throws `ApiError` if unable to create group
+ */
+const createPortfolioGroup = async (
+  req: Request<unknown, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { userId, name, color, portfolios }: PortfolioGroupRequestBody =
+    req.body;
+  // Assert the request format was valid
+  assertExists(userId, 'Invalid userId provided');
+  assertExists(name, 'Invalid name provided');
+  assertEnum(PortfolioColor, color, 'Invalid color provided');
+  // Create a porfolio group in the DB using the request parameters/data
+  const newGroup: PortfolioGroup = {
+    userId,
+    name,
+    color,
+  };
+  const groupResponse = await PortfolioGroupModel.createPortfolioGroup(
+    newGroup
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!groupResponse) {
+    throw new ApiError(
+      'Unable to create portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // Create relations for each portfolio
+  const groupId = groupResponse.id;
+  const addPortfoliosResponse = await PortfolioGroupModel.addPortfoliosToGroup(
+    groupId,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!addPortfoliosResponse) {
+    throw new ApiError(
+      'Unable to add portfolios to group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: groupResponse });
+};
+
+/**
+ * Deletes a portfolio group and it's relations from the database.
+ * @param req Request with an `id` field
+ * @param res Deleted portfolio group's information
+ */
+const deletePortfolioGroup = async (
+  req: Request<unknown, unknown, Identifiable>,
+  res: Response
+): Promise<void> => {
+  const { id: userId } = req.body;
+  // Assert the request format was valid
+  assertExists(userId, 'Invalid ID provided');
+  // Delete the group + relations from the DB
+  const response = await PortfolioGroupModel.deletePortfolioGroup(userId);
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to delete portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+/**
+ * Retrieves a Portfolio group by id. Uses URLParams.
+ * @param req Request with id URL parameter
+ * @param res Response with group data
+ * @throws `ApiError` if unable to retrieve group
+ */
+const getPortfolioGroup = async (
+  req: Request<Identifiable>,
+  res: Response
+): Promise<void> => {
+  const { id } = req.params;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid ID provided');
+  // Retrieve data
+  const response = await PortfolioGroupModel.getPortfolioGroup(id);
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to retrieve portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+const addPortfoliosToGroup = async (
+  req: Request<Identifiable, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { id } = req.params;
+  const { portfolios } = req.body;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid Id provided');
+  assertExists(portfolios, 'Invalid Portfolios array provided'); // Basic validation
+  // Add portfolios
+  const response = await PortfolioGroupModel.addPortfoliosToGroup(
+    id,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to add portfolios to group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+const removePortfoliosFromGroup = async (
+  req: Request<Identifiable, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { id } = req.params;
+  const { portfolios } = req.body;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid Id provided');
+  assertExists(portfolios, 'Invalid Portfolios array provided'); // Basic validation
+  // Remove portfolios from group
+  const response = await PortfolioGroupModel.removePortfoliosFromGroup(
+    id,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to remove portfolios from group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ removed: response });
+};
+
+export default module.exports = {
+  createPortfolioGroup,
+  deletePortfolioGroup,
+  getPortfolioGroup,
+  addPortfoliosToGroup,
+  removePortfoliosFromGroup,
+};

--- a/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
@@ -84,9 +84,6 @@ const updatePortfolioGroup = async (
   if (updatedData.color) {
     assertEnum(PortfolioColor, updatedData.color, 'Invalid color provided');
   }
-  if (updatedData.name) {
-    assertExists(updatedData.name, 'Invalid name provided');
-  }
   // Update the group in the DB
   const response = await PortfolioGroupModel.updatePortfolioGroup(
     id,

--- a/apps/augury-backend/src/controllers/auth/SessionController.ts
+++ b/apps/augury-backend/src/controllers/auth/SessionController.ts
@@ -1,4 +1,4 @@
-import mongoose, { Types } from 'mongoose';
+import mongoose from 'mongoose';
 import { AxiosError } from 'axios';
 import jwt from '../../config/utils/jwt';
 import SessionModel from '../../models/auth/SessionModel';
@@ -6,6 +6,7 @@ import Session from '../../config/interfaces/Session';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import ApiError from '../../errors/ApiError';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Creates or updates the User's current session based on the passed `userId`
@@ -15,10 +16,7 @@ import ApiError from '../../errors/ApiError';
  * @returns `Session` document
  * @throws `Error` if Axios request fails or an unknown error occurs
  */
-async function getCurrentSession(
-  userId: Types.ObjectId | string,
-  googleToken: string
-) {
+async function getCurrentSession(userId: DocumentId, googleToken: string) {
   const id = new mongoose.Types.ObjectId(userId);
   const session: Session = {
     userId: id,

--- a/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
@@ -1,9 +1,9 @@
-import { Types } from 'mongoose';
 import PortfolioDefaultSchema from '../../config/schemas/PortfolioDefaultSchema';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves the portfolio defaults for the provided `userId`
@@ -11,7 +11,7 @@ import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
  * @returns a `PorfolioDefault` document
  * @throws `ApiError` if defaults could not be retrieved
  */
-const getPortfolioDefaults = async (userId: string | Types.ObjectId) => {
+const getPortfolioDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOne({ userId });
 
   if (!defaults) {
@@ -75,7 +75,7 @@ const updatePortfolioDefaults = async (data: Partial<PortfolioDefault>) => {
  * @returns Removed user defaults data
  * @throws `ApiError` if defaults could not be deleted
  */
-const deletePortfolioDefaults = async (userId: string | Types.ObjectId) => {
+const deletePortfolioDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOneAndDelete({
     userId,
   });
@@ -96,7 +96,7 @@ const deletePortfolioDefaults = async (userId: string | Types.ObjectId) => {
  * @param userId Mongoose document id of the user
  * @returns True if defaults exist, false otherwise.
  */
-const userHasDefaults = async (userId: string | Types.ObjectId) => {
+const userHasDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOne({ userId });
   return defaults != null;
 };

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -83,11 +83,9 @@ const updatePortfolioGroup = async (
   id: DocumentId,
   data: Partial<PortfolioGroup>
 ) => {
-  const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
-    { id },
-    data,
-    { new: true }
-  );
+  const updatedGroup = await PortfolioGroupSchema.findByIdAndUpdate(id, data, {
+    new: true,
+  });
 
   if (!updatedGroup) {
     throw new ApiError(

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -1,4 +1,3 @@
-import { Types } from 'mongoose';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
@@ -6,6 +5,7 @@ import PortfolioGroupSchema from '../../config/schemas/PortfolioGroupSchema';
 import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
 import PortfolioGroupRelationSchema from '../../config/schemas/PortfolioGroupRelationSchema';
 import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelation';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a portfolio group by id
@@ -13,7 +13,7 @@ import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelati
  * @returns `PorfolioGroup` document
  * @throws `ApiError` if group could not be retrieved
  */
-const getPortfolioGroup = async (id: string | Types.ObjectId) => {
+const getPortfolioGroup = async (id: DocumentId) => {
   const group = await PortfolioGroupSchema.findById(id);
 
   if (!group) {
@@ -53,7 +53,7 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
  * @returns Removed group data
  * @throws `ApiError` if group could not be deleted
  */
-const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
+const deletePortfolioGroup = async (id: DocumentId) => {
   const group = await PortfolioGroupSchema.findByIdAndDelete(id);
 
   // Also remove associated relations
@@ -80,7 +80,7 @@ const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
  * @throws `ApiError` if groups do not exist or could not be updated
  */
 const updatePortfolioGroup = async (
-  id: string | Types.ObjectId,
+  id: DocumentId,
   data: Partial<PortfolioGroup>
 ) => {
   const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
@@ -106,11 +106,11 @@ const updatePortfolioGroup = async (
  * @param portfolioIds IDs of the portfolios to add to the group
  */
 const addPortfoliosToGroup = async (
-  groupId: string | Types.ObjectId,
-  portfolioIds: (string | Types.ObjectId)[]
+  groupId: DocumentId,
+  portfolioIds: DocumentId[]
 ) => {
   const portfolioIdToGroupRelation = (
-    id: string | Types.ObjectId
+    id: DocumentId
   ): PortfolioGroupRelation => ({
     portfolioId: id,
     portfolioGroupId: groupId,
@@ -135,8 +135,8 @@ const addPortfoliosToGroup = async (
  * @param portfolioIds IDs of the portfolios to remove from the group
  */
 const removePortfoliosFromGroup = async (
-  groupId: string | Types.ObjectId,
-  portfolioIds: (string | Types.ObjectId)[]
+  groupId: DocumentId,
+  portfolioIds: DocumentId[]
 ) => {
   const relationDocs = await PortfolioGroupRelationSchema.deleteMany({
     portfolioGroupId: groupId,

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -63,7 +63,7 @@ const deletePortfolioGroup = async (id: DocumentId) => {
 
   if (!group) {
     throw new ApiError(
-      'Unable to delete groups for user.',
+      'Unable to delete group.',
       StatusCode.INTERNAL_ERROR,
       Severity.MED
     );
@@ -104,6 +104,7 @@ const updatePortfolioGroup = async (
  * Adds group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to add to the group
+ * @returns Updated PortfolioGroup
  */
 const addPortfoliosToGroup = async (
   groupId: DocumentId,
@@ -126,13 +127,14 @@ const addPortfoliosToGroup = async (
     );
   }
 
-  return relationDocs;
+  return await getPortfolioGroup(groupId);
 };
 
 /**
  * Removes group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to remove from the group
+ * @returns Updated PortfolioGroup
  */
 const removePortfoliosFromGroup = async (
   groupId: DocumentId,
@@ -151,7 +153,7 @@ const removePortfoliosFromGroup = async (
     );
   }
 
-  return relationDocs;
+  return await getPortfolioGroup(groupId);
 };
 
 export default module.exports = {

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -156,6 +156,25 @@ const removePortfoliosFromGroup = async (
   return await getPortfolioGroup(groupId);
 };
 
+/**
+ * Retrieves all `PortfolioGroup`s for a specific user.
+ * @param userId User's document ID
+ * @returns Array of `PortfolioGroup`s
+ */
+const getPortfolioGroupsByUserId = async (userId: DocumentId) => {
+  const groups = await PortfolioGroupSchema.find({ userId });
+
+  if (!groups) {
+    throw new ApiError(
+      'Unable to find Portfolio groups for this user',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return groups;
+};
+
 export default module.exports = {
   createPortfolioGroup,
   deletePortfolioGroup,
@@ -163,4 +182,5 @@ export default module.exports = {
   getPortfolioGroup,
   addPortfoliosToGroup,
   removePortfoliosFromGroup,
+  getPortfolioGroupsByUserId,
 };

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -1,0 +1,164 @@
+import { Types } from 'mongoose';
+import ApiError from '../../errors/ApiError';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import PortfolioGroupSchema from '../../config/schemas/PortfolioGroupSchema';
+import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
+import PortfolioGroupRelationSchema from '../../config/schemas/PortfolioGroupRelationSchema';
+import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelation';
+
+/**
+ * Retrieves a portfolio group by id
+ * @param id Portfolio Group ID
+ * @returns `PorfolioGroup` document
+ * @throws `ApiError` if group could not be retrieved
+ */
+const getPortfolioGroup = async (id: string | Types.ObjectId) => {
+  const group = await PortfolioGroupSchema.findById(id);
+
+  if (!group) {
+    throw new ApiError(
+      'Unable to find group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Creates a portfolio group based on the passed data
+ * @param groupData `PortfolioGroup` object
+ * @returns new `PortfolioGroup` document
+ * @throws `ApiError` if group could not be created
+ */
+const createPortfolioGroup = async (groupData: PortfolioGroup) => {
+  const group = await PortfolioGroupSchema.create(groupData);
+
+  if (!group) {
+    throw new ApiError(
+      'Portfolio group could not be created.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Deletes a portfolio group from the database
+ * @param id Portfolio Group ID
+ * @returns Removed group data
+ * @throws `ApiError` if group could not be deleted
+ */
+const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
+  const group = await PortfolioGroupSchema.findByIdAndDelete(id);
+
+  // Also remove associated relations
+  await PortfolioGroupRelationSchema.deleteMany({
+    portfolioGroupId: id,
+  });
+
+  if (!group) {
+    throw new ApiError(
+      'Unable to delete groups for user.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Updates a Portfolio group based on the passed data.
+ * @param id Portfolio Group ID
+ * @param data Updated `PortfolioGroup` details
+ * @returns updated `PortfolioGroup` document
+ * @throws `ApiError` if groups do not exist or could not be updated
+ */
+const updatePortfolioGroup = async (
+  id: string | Types.ObjectId,
+  data: Partial<PortfolioGroup>
+) => {
+  const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
+    { id },
+    data,
+    { new: true }
+  );
+
+  if (!updatedGroup) {
+    throw new ApiError(
+      'Group could not be updated.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return updatedGroup;
+};
+
+/**
+ * Adds group relations for the provided portfolios
+ * @param groupId Portfolio Group ID
+ * @param portfolioIds IDs of the portfolios to add to the group
+ */
+const addPortfoliosToGroup = async (
+  groupId: string | Types.ObjectId,
+  portfolioIds: (string | Types.ObjectId)[]
+) => {
+  const portfolioIdToGroupRelation = (
+    id: string | Types.ObjectId
+  ): PortfolioGroupRelation => ({
+    portfolioId: id,
+    portfolioGroupId: groupId,
+  });
+  const relations = portfolioIds.map(portfolioIdToGroupRelation);
+  const relationDocs = await PortfolioGroupRelationSchema.create(relations);
+
+  if (!relationDocs) {
+    throw new ApiError(
+      'Portfolios could not be added to group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return relationDocs;
+};
+
+/**
+ * Removes group relations for the provided portfolios
+ * @param groupId Portfolio Group ID
+ * @param portfolioIds IDs of the portfolios to remove from the group
+ */
+const removePortfoliosFromGroup = async (
+  groupId: string | Types.ObjectId,
+  portfolioIds: (string | Types.ObjectId)[]
+) => {
+  const relationDocs = await PortfolioGroupRelationSchema.deleteMany({
+    portfolioGroupId: groupId,
+    portfolioId: { $in: portfolioIds },
+  });
+
+  if (!relationDocs) {
+    throw new ApiError(
+      'Portfolios could not be removed from group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return relationDocs;
+};
+
+export default module.exports = {
+  createPortfolioGroup,
+  deletePortfolioGroup,
+  updatePortfolioGroup,
+  getPortfolioGroup,
+  addPortfoliosToGroup,
+  removePortfoliosFromGroup,
+};

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -48,7 +48,7 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
 };
 
 /**
- * Deletes a portfolio group from the database
+ * Deletes a portfolio group from the database and it's relations
  * @param id Portfolio Group ID
  * @returns Removed group data
  * @throws `ApiError` if group could not be deleted

--- a/apps/augury-backend/src/models/auth/SessionModel.ts
+++ b/apps/augury-backend/src/models/auth/SessionModel.ts
@@ -4,6 +4,7 @@ import StatusCode from '../../config/enums/StatusCode';
 import Session from '../../config/interfaces/Session';
 import SessionSchema from '../../config/schemas/SessionSchema';
 import ApiError from '../../errors/ApiError';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a `Session` based on the passed `userId`
@@ -11,7 +12,7 @@ import ApiError from '../../errors/ApiError';
  * @returns `Session` document
  * @throws ApiError if the session does not exist
  */
-const getSessionByUserId = async (userId: mongoose.Types.ObjectId | string) => {
+const getSessionByUserId = async (userId: DocumentId) => {
   const id = new mongoose.Types.ObjectId(userId);
   const session = await SessionSchema.findOne({ userId: id });
 

--- a/apps/augury-backend/src/models/auth/UserModel.ts
+++ b/apps/augury-backend/src/models/auth/UserModel.ts
@@ -1,10 +1,10 @@
-import mongoose from 'mongoose';
 import User from '../../config/interfaces/User';
 import UserSchema from '../../config/schemas/UserSchema';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import SessionController from '../../controllers/auth/SessionController';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a `User` based on passed id
@@ -12,7 +12,7 @@ import SessionController from '../../controllers/auth/SessionController';
  * @returns `User` document
  * @throws ApiError if user doesn't exists/invalid ID
  */
-const getUser = async (id: string | mongoose.Types.ObjectId) => {
+const getUser = async (id: DocumentId) => {
   const user = await UserSchema.findById(id);
 
   if (!user) {
@@ -73,10 +73,7 @@ const createUser = async (data: User) => {
  * @returns Updated user data
  * @throws ApiError if user doesn't exist/invalid id, or user couldn't be updated
  */
-const updateUser = async (
-  id: string | mongoose.Types.ObjectId,
-  data: Partial<User>
-) => {
+const updateUser = async (id: DocumentId, data: Partial<User>) => {
   const user = await UserSchema.findById(id);
 
   if (!user) {
@@ -116,7 +113,7 @@ const updateUser = async (
  * @param id Mongoose document id
  * @returns Removed user data
  */
-const deleteUser = async (id: string | mongoose.Types.ObjectId) => {
+const deleteUser = async (id: DocumentId) => {
   const user = await UserSchema.findByIdAndDelete(id);
 
   if (!user) {

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -26,6 +26,7 @@ portfolioRouter
 portfolioRouter
   .route('/group')
   .post(asyncErrorHandler(PortfolioGroupController.createPortfolioGroup))
+  .put(asyncErrorHandler(PortfolioGroupController.updatePortfolioGroup))
   .delete(asyncErrorHandler(PortfolioGroupController.deletePortfolioGroup));
 
 portfolioRouter

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -36,4 +36,8 @@ portfolioRouter
     asyncErrorHandler(PortfolioGroupController.removePortfoliosFromGroup)
   );
 
+portfolioRouter
+  .route('/group/user/:id')
+  .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroupsByUserId));
+
 export default portfolioRouter;

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -2,12 +2,14 @@ import express, { Router } from 'express';
 // import { verifyAccessToken } from '../middlewares/AttachUserHandler';
 import asyncErrorHandler from '../middlewares/AsyncErrorHandler';
 import PortfolioDefaultController from '../controllers/auth/PortfolioDefaultController';
+import PortfolioGroupController from '../controllers/auth/PortfolioGroupController';
 
 const portfolioRouter: Router = express.Router();
 
 // Uncomment if we want to verify the client's auth token for all routes
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
+// ================ Portfolio Defaults ================
 portfolioRouter
   .route('/defaults')
   .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults));
@@ -19,4 +21,19 @@ portfolioRouter
   .delete(
     asyncErrorHandler(PortfolioDefaultController.deletePortfolioDefaults)
   );
+
+// ================ Portfolio Groups ================
+portfolioRouter
+  .route('/group')
+  .post(asyncErrorHandler(PortfolioGroupController.createPortfolioGroup))
+  .delete(asyncErrorHandler(PortfolioGroupController.deletePortfolioGroup));
+
+portfolioRouter
+  .route('/group/:id')
+  .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroup))
+  .put(asyncErrorHandler(PortfolioGroupController.addPortfoliosToGroup))
+  .delete(
+    asyncErrorHandler(PortfolioGroupController.removePortfoliosFromGroup)
+  );
+
 export default portfolioRouter;


### PR DESCRIPTION
This implements the basic functionality of the Portfolio Groups. This does not do anything extra in terms of Portfolio functionality (e.g. Does not retrieve extra Portfolio data or the balance yet)

# Changes Made
- Created `PortfolioGroupController` and `PortfolioGroupModel` to handle group creation and management.
- Has routes and functions to:
  - `createPortfolioGroup`,
  - `updatePortfolioGroup`,
  - `deletePortfolioGroup`,
  - `getPortfolioGroup`,
  - `addPortfoliosToGroup`,
  - `removePortfoliosFromGroup`,
  - `getPortfolioGroupsByUserId`,
  - (See `PortfolioRoutes.ts` for route bindings)
- Created `DocumentId` type to simplify the number of Type unions throughout the models
- Added Request and Response Types for Group routes in interfaces