### PR TITLE
Basic Portfolio Functionality

### DIFF
--- a/apps/augury-backend/src/config/interfaces/BuyRecord.ts
+++ b/apps/augury-backend/src/config/interfaces/BuyRecord.ts
@@ -1,8 +1,8 @@
-import { Types } from 'mongoose';
 import Identifiable from './Identifiable';
+import DocumentId from './DocumentId';
 
 export default interface BuyRecord extends Identifiable {
-  stockId: Types.ObjectId | string;
+  stockId: DocumentId;
   shares: number;
   boughtAtPrice: number;
 }

--- a/apps/augury-backend/src/config/interfaces/DocumentId.ts
+++ b/apps/augury-backend/src/config/interfaces/DocumentId.ts
@@ -1,0 +1,5 @@
+import { Types } from 'mongoose';
+
+type DocumentId = string | Types.ObjectId;
+
+export default DocumentId;

--- a/apps/augury-backend/src/config/interfaces/Portfolio.ts
+++ b/apps/augury-backend/src/config/interfaces/Portfolio.ts
@@ -6,7 +6,11 @@ export default interface Portfolio extends Identifiable {
   name: string; // Portfolio name
   // risk?: PortfolioRisk; // Optional risk if `useCustomRisk` is true
   // useCustomRisk: boolean; // If true, indicates custom risk settings are used
-  riskPercentage1?: number;
-  riskPercentage2?: number;
+  riskPercentage1: number;
+  riskPercentage2: number;
   sectorTags?: Sectors[];
+}
+
+export interface PortfolioResponse {
+  portfolio: Portfolio;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioDefault.ts
@@ -1,6 +1,6 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Portfolio from './Portfolio';
 
 export default interface PortfolioDefault extends Portfolio {
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -7,3 +7,15 @@ export default interface PortfolioGroup extends Identifiable {
   color: PortfolioColor;
   userId: DocumentId;
 }
+
+export type PortfolioGroupRequestBody = PortfolioGroup & {
+  portfolios?: DocumentId[];
+};
+
+export type PortfolioGroupResponse = {
+  group: PortfolioGroup;
+};
+
+export type PortfolioGroupsResponse = {
+  groups: PortfolioGroup[];
+};

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -1,9 +1,9 @@
-import { Types } from 'mongoose';
 import PortfolioColor from '../enums/PortfolioColor';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface PortfolioGroup extends Identifiable {
   name: string;
   color: PortfolioColor;
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroupRelation.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface PortfolioGroupRelation extends Identifiable {
-  portfolioId: Types.ObjectId | string;
-  portfolioGroupId: Types.ObjectId | string;
+  portfolioId: DocumentId;
+  portfolioGroupId: DocumentId;
 }

--- a/apps/augury-backend/src/config/interfaces/Session.ts
+++ b/apps/augury-backend/src/config/interfaces/Session.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
 import Identifiable from './Identifiable';
+import DocumentId from './DocumentId';
 
 export default interface Session extends Identifiable {
-  userId: Types.ObjectId | string;
+  userId: DocumentId;
   token: string;
 }

--- a/apps/augury-backend/src/config/interfaces/Stock.ts
+++ b/apps/augury-backend/src/config/interfaces/Stock.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
+import DocumentId from './DocumentId';
 import Identifiable from './Identifiable';
 
 export default interface Stock extends Identifiable {
-  portfolioId: Types.ObjectId | string;
+  portfolioId: DocumentId;
   symbol: string;
 }

--- a/apps/augury-backend/src/config/schemas/PortfolioDefaultSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioDefaultSchema.ts
@@ -13,8 +13,8 @@ const schema = new mongoose.Schema<PortfolioDefault>({
   //   // default: PortfolioRisk.CONSERVATIVE, // Default value for status
   // },
   // useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
-  riskPercentage1: { type: Number },
-  riskPercentage2: { type: Number },
+  riskPercentage1: { type: Number, required: true },
+  riskPercentage2: { type: Number, required: true },
   sectorTags: [String], // Would use custom validation but it's weird to enforce. Will validate through business logic
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware

--- a/apps/augury-backend/src/config/schemas/PortfolioGroupRelationSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioGroupRelationSchema.ts
@@ -16,6 +16,8 @@ const schema = new mongoose.Schema<PortfolioGroupRelation>({
   },
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware
+// Prevent duplicated relations
+schema.index({ portfolioId: 1, portfolioGroupId: 1 }, { unique: true });
 
 const PortfolioGroupRelationSchema = mongoose.model<PortfolioGroupRelation>(
   'PortfolioGroupRelation',

--- a/apps/augury-backend/src/config/schemas/PortfolioSchema.ts
+++ b/apps/augury-backend/src/config/schemas/PortfolioSchema.ts
@@ -12,8 +12,8 @@ const schema = new mongoose.Schema<Portfolio>({
   //   // default: PortfolioRisk.CONSERVATIVE, // Default value for status
   // },
   // useCustomRisk: { type: Boolean, required: true }, // If true, custom risk settings are used
-  riskPercentage1: { type: Number },
-  riskPercentage2: { type: Number },
+  riskPercentage1: { type: Number, required: true },
+  riskPercentage2: { type: Number, required: true },
   sectorTags: [String], // Would use custom validation but it's weird to enforce. Will validate through business logic
 });
 schema.plugin(stripAndFormatIds); // toJSON middleware

--- a/apps/augury-backend/src/config/utils/validation.ts
+++ b/apps/augury-backend/src/config/utils/validation.ts
@@ -69,3 +69,28 @@ export function assertPortfolioDefaultsFormat(defaults: Portfolio) {
     }
   }
 }
+
+/**
+ * Asserts that a passed risk composition is valid and totals to 100%.
+ * @param riskPercentage1 Number
+ * @param riskPercentage2 Number
+ * @throws `ClientError` if risk composition doesn't add to 100.
+ */
+export function assertValidRiskComposition(
+  riskPercentage1?: number,
+  riskPercentage2?: number,
+  required = true
+) {
+  // If required == true, short-circuit and assert both were passed, else see if any was passed.
+  if (required || riskPercentage1 || riskPercentage2) {
+    // Assert that updating one risk percentage should update the other
+    assertNumber(riskPercentage1, 'Invalid risk percentage 1 provided');
+    assertNumber(riskPercentage2, 'Invalid risk percentage 2 provided');
+    if (riskPercentage1 + riskPercentage2 != 100) {
+      throw new ClientError(
+        'Invalid risk composition provided (must add to 100)',
+        StatusCode.BAD_REQUEST
+      );
+    }
+  }
+}

--- a/apps/augury-backend/src/controllers/auth/PortfolioController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioController.ts
@@ -1,0 +1,165 @@
+import { Request, Response } from 'express';
+import {
+  assertEnum,
+  assertExists,
+  assertValidRiskComposition,
+} from '../../config/utils/validation';
+import PortfolioModel from '../../models/auth/PortfolioModel';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import Portfolio, {
+  PortfolioResponse,
+} from '../../config/interfaces/Portfolio';
+import ApiError from '../../errors/ApiError';
+import Sectors from '../../config/enums/Sectors';
+import Identifiable from '../../config/interfaces/Identifiable';
+
+/**
+ * Creates a new Portfolio based on the passed request body
+ * @param req Request with `Portfolio` fields inside the body
+ * @param res Response with new Portfolio
+ * @throws `ClientError` if request is invalid
+ * @throws `ApiError` if unable to create portfolio
+ */
+const createPortfolio = async (
+  req: Request<unknown, unknown, Portfolio>,
+  res: Response<PortfolioResponse>
+) => {
+  const { name, riskPercentage1, riskPercentage2, sectorTags }: Portfolio =
+    req.body;
+  // Assert the request format was valid
+  assertExists(name, 'Invalid Name provided');
+  assertValidRiskComposition(riskPercentage1, riskPercentage2);
+  if (sectorTags && Array.isArray(sectorTags)) {
+    for (const tag of sectorTags) {
+      assertEnum(Sectors, tag, 'Invalid sector tag provided');
+    }
+  }
+  // Create a user in the DB using the request parameters/data
+  const newPortfolio: Portfolio = {
+    name,
+    riskPercentage1,
+    riskPercentage2,
+    sectorTags,
+  };
+  const response = await PortfolioModel.createPortfolio(newPortfolio);
+
+  if (!response) {
+    // we throw an API error since this means something errored out with our server end
+    throw new ApiError(
+      'Unable to create this portfolio',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // send the portfolio back after model runs logic
+  res.status(StatusCode.OK).send({ portfolio: response });
+};
+
+/**
+ * Retrieves a Portfolio from the database by ID
+ * @param req Request with id URL parameter
+ * @param res Response with a `Portfolio`
+ * @throws `ClientError` if request is invalid
+ * @throws `ApiError` if unable to retrieve the portfolio
+ */
+const getPortfolio = async (
+  req: Request<Identifiable>,
+  res: Response<PortfolioResponse>
+) => {
+  const { id: portfolioId } = req.params;
+  // Assert the request format was valid
+  assertExists(portfolioId, 'Invalid ID provided');
+  // Retrieve data from the DB using request parameters/data
+  const response = await PortfolioModel.getPortfolio(portfolioId);
+
+  if (!response) {
+    // we throw an API error since this means something errored out with our server end
+    throw new ApiError(
+      'Unable to retrieve this portfolio',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // Send the portfolio back after model runs logic
+  res.status(StatusCode.OK).send({ portfolio: response });
+};
+
+/**
+ * Updates a portfolio based on the passed request body
+ * @param req Request with `Portfolio` fields in body and `id` URL parameter
+ * @param res Response with updated Portfolio
+ * @throws `ClientError` if request is invalid (missing/invalid `userId`)
+ * @throws `ApiError` if unable to create defaults
+ */
+const updatePortfolio = async (
+  req: Request<Identifiable, unknown, Portfolio>,
+  res: Response<PortfolioResponse>
+) => {
+  const { id: portfolioId } = req.params;
+  const { name, riskPercentage1, riskPercentage2, sectorTags }: Portfolio =
+    req.body;
+  // Assert the request format was valid
+  assertExists(portfolioId, 'Invalid ID provided');
+  assertValidRiskComposition(riskPercentage1, riskPercentage2, false);
+  if (sectorTags && Array.isArray(sectorTags)) {
+    for (const tag of sectorTags) {
+      assertEnum(Sectors, tag, 'Invalid sector tag provided');
+    }
+  }
+  // Update the Portfolio in the DB using the request parameters/data
+  const updatedPortfolio: Portfolio = {
+    id: portfolioId,
+    name,
+    riskPercentage1,
+    riskPercentage2,
+    sectorTags,
+  };
+
+  const response = await PortfolioModel.updatePortfolio(updatedPortfolio);
+
+  if (!response) {
+    // we throw an API error since this means something errored out with our server end
+    throw new ApiError(
+      'Unable to update this portfolio',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // send the portfolio back after model runs logic
+  res.status(StatusCode.OK).send({ portfolio: response });
+};
+
+/**
+ * Deletes portfolio from the database.
+ * @param req Request with an `id` field
+ * @param res Deleted portfolio information
+ */
+const deletePortfolio = async (
+  req: Request<Identifiable>,
+  res: Response<PortfolioResponse>
+) => {
+  const { id: portfolioId } = req.params;
+  // Assert the request format was valid
+  assertExists(portfolioId, 'Invalid ID provided');
+  // Delete the portfolio from the DB
+  const response = await PortfolioModel.deletePortfolio(portfolioId);
+
+  if (!response) {
+    // we throw an API error since this means something errored out with our server end
+    throw new ApiError(
+      'Unable to delete this portfolio',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // send the portfolio back after model runs logic
+  res.status(StatusCode.OK).send({ portfolio: response });
+};
+
+export default module.exports = {
+  getPortfolio,
+  createPortfolio,
+  updatePortfolio,
+  deletePortfolio,
+};

--- a/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
@@ -1,0 +1,179 @@
+import { Request, Response } from 'express';
+import { assertEnum, assertExists } from '../../config/utils/validation';
+import ApiError from '../../errors/ApiError';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import PortfolioGroupModel from '../../models/auth/PortfolioGroupModel';
+import PortfolioColor from '../../config/enums/PortfolioColor';
+import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
+import Identifiable from '../../config/interfaces/Identifiable';
+import DocumentId from '../../config/interfaces/DocumentId';
+
+type PortfolioGroupRequestBody = PortfolioGroup & {
+  portfolios?: DocumentId[];
+};
+
+/**
+ * Creates a new portfolio group based on the passed request body
+ * @param req Request with `PortfolioGroup` fields
+ * @param res Response with new portfolio group
+ * @throws `ClientError` if request is invalid
+ * @throws `ApiError` if unable to create group
+ */
+const createPortfolioGroup = async (
+  req: Request<unknown, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { userId, name, color, portfolios }: PortfolioGroupRequestBody =
+    req.body;
+  // Assert the request format was valid
+  assertExists(userId, 'Invalid userId provided');
+  assertExists(name, 'Invalid name provided');
+  assertEnum(PortfolioColor, color, 'Invalid color provided');
+  // Create a porfolio group in the DB using the request parameters/data
+  const newGroup: PortfolioGroup = {
+    userId,
+    name,
+    color,
+  };
+  const groupResponse = await PortfolioGroupModel.createPortfolioGroup(
+    newGroup
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!groupResponse) {
+    throw new ApiError(
+      'Unable to create portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // Create relations for each portfolio
+  const groupId = groupResponse.id;
+  const addPortfoliosResponse = await PortfolioGroupModel.addPortfoliosToGroup(
+    groupId,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!addPortfoliosResponse) {
+    throw new ApiError(
+      'Unable to add portfolios to group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: groupResponse });
+};
+
+/**
+ * Deletes a portfolio group and it's relations from the database.
+ * @param req Request with an `id` field
+ * @param res Deleted portfolio group's information
+ */
+const deletePortfolioGroup = async (
+  req: Request<unknown, unknown, Identifiable>,
+  res: Response
+): Promise<void> => {
+  const { id: userId } = req.body;
+  // Assert the request format was valid
+  assertExists(userId, 'Invalid ID provided');
+  // Delete the group + relations from the DB
+  const response = await PortfolioGroupModel.deletePortfolioGroup(userId);
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to delete portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+/**
+ * Retrieves a Portfolio group by id. Uses URLParams.
+ * @param req Request with id URL parameter
+ * @param res Response with group data
+ * @throws `ApiError` if unable to retrieve group
+ */
+const getPortfolioGroup = async (
+  req: Request<Identifiable>,
+  res: Response
+): Promise<void> => {
+  const { id } = req.params;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid ID provided');
+  // Retrieve data
+  const response = await PortfolioGroupModel.getPortfolioGroup(id);
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to retrieve portfolio group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+const addPortfoliosToGroup = async (
+  req: Request<Identifiable, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { id } = req.params;
+  const { portfolios } = req.body;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid Id provided');
+  assertExists(portfolios, 'Invalid Portfolios array provided'); // Basic validation
+  // Add portfolios
+  const response = await PortfolioGroupModel.addPortfoliosToGroup(
+    id,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to add portfolios to group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ group: response });
+};
+
+const removePortfoliosFromGroup = async (
+  req: Request<Identifiable, unknown, PortfolioGroupRequestBody>,
+  res: Response
+) => {
+  const { id } = req.params;
+  const { portfolios } = req.body;
+  // Assert the request format was valid
+  assertExists(id, 'Invalid Id provided');
+  assertExists(portfolios, 'Invalid Portfolios array provided'); // Basic validation
+  // Remove portfolios from group
+  const response = await PortfolioGroupModel.removePortfoliosFromGroup(
+    id,
+    portfolios
+  );
+  // Throw error if somehow we errored on the server-side
+  if (!response) {
+    throw new ApiError(
+      'Unable to remove portfolios from group',
+      StatusCode.INTERNAL_ERROR,
+      Severity.LOW
+    );
+  }
+  // Return response data
+  res.status(StatusCode.OK).send({ removed: response });
+};
+
+export default module.exports = {
+  createPortfolioGroup,
+  deletePortfolioGroup,
+  getPortfolioGroup,
+  addPortfoliosToGroup,
+  removePortfoliosFromGroup,
+};

--- a/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
+++ b/apps/augury-backend/src/controllers/auth/PortfolioGroupController.ts
@@ -84,9 +84,6 @@ const updatePortfolioGroup = async (
   if (updatedData.color) {
     assertEnum(PortfolioColor, updatedData.color, 'Invalid color provided');
   }
-  if (updatedData.name) {
-    assertExists(updatedData.name, 'Invalid name provided');
-  }
   // Update the group in the DB
   const response = await PortfolioGroupModel.updatePortfolioGroup(
     id,

--- a/apps/augury-backend/src/controllers/auth/SessionController.ts
+++ b/apps/augury-backend/src/controllers/auth/SessionController.ts
@@ -1,4 +1,4 @@
-import mongoose, { Types } from 'mongoose';
+import mongoose from 'mongoose';
 import { AxiosError } from 'axios';
 import jwt from '../../config/utils/jwt';
 import SessionModel from '../../models/auth/SessionModel';
@@ -6,6 +6,7 @@ import Session from '../../config/interfaces/Session';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import ApiError from '../../errors/ApiError';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Creates or updates the User's current session based on the passed `userId`
@@ -15,10 +16,7 @@ import ApiError from '../../errors/ApiError';
  * @returns `Session` document
  * @throws `Error` if Axios request fails or an unknown error occurs
  */
-async function getCurrentSession(
-  userId: Types.ObjectId | string,
-  googleToken: string
-) {
+async function getCurrentSession(userId: DocumentId, googleToken: string) {
   const id = new mongoose.Types.ObjectId(userId);
   const session: Session = {
     userId: id,

--- a/apps/augury-backend/src/middlewares/CustomErrorHandler.ts
+++ b/apps/augury-backend/src/middlewares/CustomErrorHandler.ts
@@ -9,7 +9,7 @@ export default function customErrorHandler(
   _next: NextFunction
 ) {
   if (err instanceof ApiError) {
-    console.error(err.stack);
+    // console.error(err.stack);
     res.status(err.statusCode).send();
   } else if (err instanceof ClientError) {
     res.status(err.statusCode).send();

--- a/apps/augury-backend/src/middlewares/SchemaErrorHandler.ts
+++ b/apps/augury-backend/src/middlewares/SchemaErrorHandler.ts
@@ -1,0 +1,60 @@
+import { Error } from 'mongoose';
+import ApiError from '../errors/ApiError';
+import StatusCode from '../config/enums/StatusCode';
+import Severity from '../config/enums/Severity';
+
+interface DuplicateKeyError {
+  code: number;
+  errmsg: string;
+}
+
+// Helper function to validate error was in fact a duplicate key error.
+function isDuplicatekeyError(obj: any): obj is DuplicateKeyError {
+  return (
+    obj &&
+    typeof obj.code === 'number' &&
+    obj.code === 11000 &&
+    typeof obj.errmsg === 'string'
+  );
+}
+
+/**
+ * Error handler wrapper function to handle Mongoose Schema errors gracefully.
+ * @param promise to await for database results
+ * @returns result from Promise
+ * @throws Custom `ApiError` if an error has occurred
+ */
+export default async function schemaErrorHandler<T>(promise: Promise<T>) {
+  try {
+    return await promise;
+  } catch (error: unknown) {
+    if (error instanceof Error.ValidationError) {
+      for (const field in error.errors) {
+        console.log(error.errors[field].message);
+      }
+      throw new ApiError(
+        'Validation error occurred',
+        StatusCode.INTERNAL_ERROR,
+        Severity.LOW
+      );
+    } else if (error instanceof Error.CastError) {
+      throw new ApiError(
+        'Invalid ID value passed from model: ' + error.value,
+        StatusCode.INTERNAL_ERROR,
+        Severity.LOW
+      );
+    } else if (isDuplicatekeyError(error)) {
+      throw new ApiError(
+        'Could not insert; duplicate key',
+        StatusCode.INTERNAL_ERROR,
+        Severity.LOW
+      );
+    } else {
+      throw new ApiError(
+        'An unknown error has occurred reading/writing from DB! ' + error,
+        StatusCode.INTERNAL_ERROR,
+        Severity.HIGH
+      );
+    }
+  }
+}

--- a/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
@@ -1,9 +1,9 @@
-import { Types } from 'mongoose';
 import PortfolioDefaultSchema from '../../config/schemas/PortfolioDefaultSchema';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves the portfolio defaults for the provided `userId`
@@ -11,7 +11,7 @@ import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
  * @returns a `PorfolioDefault` document
  * @throws `ApiError` if defaults could not be retrieved
  */
-const getPortfolioDefaults = async (userId: string | Types.ObjectId) => {
+const getPortfolioDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOne({ userId });
 
   if (!defaults) {
@@ -75,7 +75,7 @@ const updatePortfolioDefaults = async (data: Partial<PortfolioDefault>) => {
  * @returns Removed user defaults data
  * @throws `ApiError` if defaults could not be deleted
  */
-const deletePortfolioDefaults = async (userId: string | Types.ObjectId) => {
+const deletePortfolioDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOneAndDelete({
     userId,
   });
@@ -96,7 +96,7 @@ const deletePortfolioDefaults = async (userId: string | Types.ObjectId) => {
  * @param userId Mongoose document id of the user
  * @returns True if defaults exist, false otherwise.
  */
-const userHasDefaults = async (userId: string | Types.ObjectId) => {
+const userHasDefaults = async (userId: DocumentId) => {
   const defaults = await PortfolioDefaultSchema.findOne({ userId });
   return defaults != null;
 };

--- a/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioDefaultModel.ts
@@ -4,6 +4,7 @@ import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import PortfolioDefault from '../../config/interfaces/PortfolioDefault';
 import DocumentId from '../../config/interfaces/DocumentId';
+import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
 
 /**
  * Retrieves the portfolio defaults for the provided `userId`
@@ -12,7 +13,9 @@ import DocumentId from '../../config/interfaces/DocumentId';
  * @throws `ApiError` if defaults could not be retrieved
  */
 const getPortfolioDefaults = async (userId: DocumentId) => {
-  const defaults = await PortfolioDefaultSchema.findOne({ userId });
+  const defaults = await SchemaErrorHandler(
+    PortfolioDefaultSchema.findOne({ userId })
+  );
 
   if (!defaults) {
     throw new ApiError(
@@ -32,7 +35,9 @@ const getPortfolioDefaults = async (userId: DocumentId) => {
  * @throws `ApiError` if defaults could not be created
  */
 const createPortfolioDefaults = async (data: PortfolioDefault) => {
-  const defaults = await PortfolioDefaultSchema.create(data);
+  const defaults = await SchemaErrorHandler(
+    PortfolioDefaultSchema.create(data)
+  );
   if (!defaults) {
     throw new ApiError(
       'Portfolio defaults could not be created.',
@@ -52,10 +57,10 @@ const createPortfolioDefaults = async (data: PortfolioDefault) => {
  */
 const updatePortfolioDefaults = async (data: Partial<PortfolioDefault>) => {
   const { userId, ...updateData }: Partial<PortfolioDefault> = data;
-  const updatedDefaults = await PortfolioDefaultSchema.findOneAndUpdate(
-    { userId },
-    updateData,
-    { new: true }
+  const updatedDefaults = await SchemaErrorHandler(
+    PortfolioDefaultSchema.findOneAndUpdate({ userId }, updateData, {
+      new: true,
+    })
   );
 
   if (!updatedDefaults) {
@@ -76,9 +81,11 @@ const updatePortfolioDefaults = async (data: Partial<PortfolioDefault>) => {
  * @throws `ApiError` if defaults could not be deleted
  */
 const deletePortfolioDefaults = async (userId: DocumentId) => {
-  const defaults = await PortfolioDefaultSchema.findOneAndDelete({
-    userId,
-  });
+  const defaults = await SchemaErrorHandler(
+    PortfolioDefaultSchema.findOneAndDelete({
+      userId,
+    })
+  );
 
   if (!defaults) {
     throw new ApiError(
@@ -97,7 +104,9 @@ const deletePortfolioDefaults = async (userId: DocumentId) => {
  * @returns True if defaults exist, false otherwise.
  */
 const userHasDefaults = async (userId: DocumentId) => {
-  const defaults = await PortfolioDefaultSchema.findOne({ userId });
+  const defaults = await SchemaErrorHandler(
+    PortfolioDefaultSchema.findOne({ userId })
+  );
   return defaults != null;
 };
 

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -83,11 +83,9 @@ const updatePortfolioGroup = async (
   id: DocumentId,
   data: Partial<PortfolioGroup>
 ) => {
-  const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
-    { id },
-    data,
-    { new: true }
-  );
+  const updatedGroup = await PortfolioGroupSchema.findByIdAndUpdate(id, data, {
+    new: true,
+  });
 
   if (!updatedGroup) {
     throw new ApiError(

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -1,4 +1,3 @@
-import { Types } from 'mongoose';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
@@ -6,6 +5,7 @@ import PortfolioGroupSchema from '../../config/schemas/PortfolioGroupSchema';
 import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
 import PortfolioGroupRelationSchema from '../../config/schemas/PortfolioGroupRelationSchema';
 import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelation';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a portfolio group by id
@@ -13,7 +13,7 @@ import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelati
  * @returns `PorfolioGroup` document
  * @throws `ApiError` if group could not be retrieved
  */
-const getPortfolioGroup = async (id: string | Types.ObjectId) => {
+const getPortfolioGroup = async (id: DocumentId) => {
   const group = await PortfolioGroupSchema.findById(id);
 
   if (!group) {
@@ -53,7 +53,7 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
  * @returns Removed group data
  * @throws `ApiError` if group could not be deleted
  */
-const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
+const deletePortfolioGroup = async (id: DocumentId) => {
   const group = await PortfolioGroupSchema.findByIdAndDelete(id);
 
   // Also remove associated relations
@@ -80,7 +80,7 @@ const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
  * @throws `ApiError` if groups do not exist or could not be updated
  */
 const updatePortfolioGroup = async (
-  id: string | Types.ObjectId,
+  id: DocumentId,
   data: Partial<PortfolioGroup>
 ) => {
   const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
@@ -106,11 +106,11 @@ const updatePortfolioGroup = async (
  * @param portfolioIds IDs of the portfolios to add to the group
  */
 const addPortfoliosToGroup = async (
-  groupId: string | Types.ObjectId,
-  portfolioIds: (string | Types.ObjectId)[]
+  groupId: DocumentId,
+  portfolioIds: DocumentId[]
 ) => {
   const portfolioIdToGroupRelation = (
-    id: string | Types.ObjectId
+    id: DocumentId
   ): PortfolioGroupRelation => ({
     portfolioId: id,
     portfolioGroupId: groupId,
@@ -135,8 +135,8 @@ const addPortfoliosToGroup = async (
  * @param portfolioIds IDs of the portfolios to remove from the group
  */
 const removePortfoliosFromGroup = async (
-  groupId: string | Types.ObjectId,
-  portfolioIds: (string | Types.ObjectId)[]
+  groupId: DocumentId,
+  portfolioIds: DocumentId[]
 ) => {
   const relationDocs = await PortfolioGroupRelationSchema.deleteMany({
     portfolioGroupId: groupId,

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -63,7 +63,7 @@ const deletePortfolioGroup = async (id: DocumentId) => {
 
   if (!group) {
     throw new ApiError(
-      'Unable to delete groups for user.',
+      'Unable to delete group.',
       StatusCode.INTERNAL_ERROR,
       Severity.MED
     );
@@ -104,6 +104,7 @@ const updatePortfolioGroup = async (
  * Adds group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to add to the group
+ * @returns Updated PortfolioGroup
  */
 const addPortfoliosToGroup = async (
   groupId: DocumentId,
@@ -126,13 +127,14 @@ const addPortfoliosToGroup = async (
     );
   }
 
-  return relationDocs;
+  return await getPortfolioGroup(groupId);
 };
 
 /**
  * Removes group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to remove from the group
+ * @returns Updated PortfolioGroup
  */
 const removePortfoliosFromGroup = async (
   groupId: DocumentId,
@@ -151,7 +153,7 @@ const removePortfoliosFromGroup = async (
     );
   }
 
-  return relationDocs;
+  return await getPortfolioGroup(groupId);
 };
 
 export default module.exports = {

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -6,6 +6,7 @@ import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
 import PortfolioGroupRelationSchema from '../../config/schemas/PortfolioGroupRelationSchema';
 import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelation';
 import DocumentId from '../../config/interfaces/DocumentId';
+import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
 
 /**
  * Retrieves a portfolio group by id
@@ -14,7 +15,7 @@ import DocumentId from '../../config/interfaces/DocumentId';
  * @throws `ApiError` if group could not be retrieved
  */
 const getPortfolioGroup = async (id: DocumentId) => {
-  const group = await PortfolioGroupSchema.findById(id);
+  const group = await SchemaErrorHandler(PortfolioGroupSchema.findById(id));
 
   if (!group) {
     throw new ApiError(
@@ -34,7 +35,9 @@ const getPortfolioGroup = async (id: DocumentId) => {
  * @throws `ApiError` if group could not be created
  */
 const createPortfolioGroup = async (groupData: PortfolioGroup) => {
-  const group = await PortfolioGroupSchema.create(groupData);
+  const group = await SchemaErrorHandler(
+    PortfolioGroupSchema.create(groupData)
+  );
 
   if (!group) {
     throw new ApiError(
@@ -54,12 +57,16 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
  * @throws `ApiError` if group could not be deleted
  */
 const deletePortfolioGroup = async (id: DocumentId) => {
-  const group = await PortfolioGroupSchema.findByIdAndDelete(id);
+  const group = await SchemaErrorHandler(
+    PortfolioGroupSchema.findByIdAndDelete(id)
+  );
 
   // Also remove associated relations
-  await PortfolioGroupRelationSchema.deleteMany({
-    portfolioGroupId: id,
-  });
+  await SchemaErrorHandler(
+    PortfolioGroupRelationSchema.deleteMany({
+      portfolioGroupId: id,
+    })
+  );
 
   if (!group) {
     throw new ApiError(
@@ -83,9 +90,11 @@ const updatePortfolioGroup = async (
   id: DocumentId,
   data: Partial<PortfolioGroup>
 ) => {
-  const updatedGroup = await PortfolioGroupSchema.findByIdAndUpdate(id, data, {
-    new: true,
-  });
+  const updatedGroup = await SchemaErrorHandler(
+    PortfolioGroupSchema.findByIdAndUpdate(id, data, {
+      new: true,
+    })
+  );
 
   if (!updatedGroup) {
     throw new ApiError(
@@ -115,7 +124,9 @@ const addPortfoliosToGroup = async (
     portfolioGroupId: groupId,
   });
   const relations = portfolioIds.map(portfolioIdToGroupRelation);
-  const relationDocs = await PortfolioGroupRelationSchema.create(relations);
+  const relationDocs = await SchemaErrorHandler(
+    PortfolioGroupRelationSchema.create(relations)
+  );
 
   if (!relationDocs) {
     throw new ApiError(
@@ -138,10 +149,12 @@ const removePortfoliosFromGroup = async (
   groupId: DocumentId,
   portfolioIds: DocumentId[]
 ) => {
-  const relationDocs = await PortfolioGroupRelationSchema.deleteMany({
-    portfolioGroupId: groupId,
-    portfolioId: { $in: portfolioIds },
-  });
+  const relationDocs = await SchemaErrorHandler(
+    PortfolioGroupRelationSchema.deleteMany({
+      portfolioGroupId: groupId,
+      portfolioId: { $in: portfolioIds },
+    })
+  );
 
   if (!relationDocs) {
     throw new ApiError(
@@ -160,7 +173,9 @@ const removePortfoliosFromGroup = async (
  * @returns Array of `PortfolioGroup`s
  */
 const getPortfolioGroupsByUserId = async (userId: DocumentId) => {
-  const groups = await PortfolioGroupSchema.find({ userId });
+  const groups = await SchemaErrorHandler(
+    PortfolioGroupSchema.find({ userId })
+  );
 
   if (!groups) {
     throw new ApiError(

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -156,6 +156,25 @@ const removePortfoliosFromGroup = async (
   return await getPortfolioGroup(groupId);
 };
 
+/**
+ * Retrieves all `PortfolioGroup`s for a specific user.
+ * @param userId User's document ID
+ * @returns Array of `PortfolioGroup`s
+ */
+const getPortfolioGroupsByUserId = async (userId: DocumentId) => {
+  const groups = await PortfolioGroupSchema.find({ userId });
+
+  if (!groups) {
+    throw new ApiError(
+      'Unable to find Portfolio groups for this user',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return groups;
+};
+
 export default module.exports = {
   createPortfolioGroup,
   deletePortfolioGroup,
@@ -163,4 +182,5 @@ export default module.exports = {
   getPortfolioGroup,
   addPortfoliosToGroup,
   removePortfoliosFromGroup,
+  getPortfolioGroupsByUserId,
 };

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -1,0 +1,164 @@
+import { Types } from 'mongoose';
+import ApiError from '../../errors/ApiError';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import PortfolioGroupSchema from '../../config/schemas/PortfolioGroupSchema';
+import PortfolioGroup from '../../config/interfaces/PortfolioGroup';
+import PortfolioGroupRelationSchema from '../../config/schemas/PortfolioGroupRelationSchema';
+import PortfolioGroupRelation from '../../config/interfaces/PortfolioGroupRelation';
+
+/**
+ * Retrieves a portfolio group by id
+ * @param id Portfolio Group ID
+ * @returns `PorfolioGroup` document
+ * @throws `ApiError` if group could not be retrieved
+ */
+const getPortfolioGroup = async (id: string | Types.ObjectId) => {
+  const group = await PortfolioGroupSchema.findById(id);
+
+  if (!group) {
+    throw new ApiError(
+      'Unable to find group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Creates a portfolio group based on the passed data
+ * @param groupData `PortfolioGroup` object
+ * @returns new `PortfolioGroup` document
+ * @throws `ApiError` if group could not be created
+ */
+const createPortfolioGroup = async (groupData: PortfolioGroup) => {
+  const group = await PortfolioGroupSchema.create(groupData);
+
+  if (!group) {
+    throw new ApiError(
+      'Portfolio group could not be created.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Deletes a portfolio group from the database
+ * @param id Portfolio Group ID
+ * @returns Removed group data
+ * @throws `ApiError` if group could not be deleted
+ */
+const deletePortfolioGroup = async (id: string | Types.ObjectId) => {
+  const group = await PortfolioGroupSchema.findByIdAndDelete(id);
+
+  // Also remove associated relations
+  await PortfolioGroupRelationSchema.deleteMany({
+    portfolioGroupId: id,
+  });
+
+  if (!group) {
+    throw new ApiError(
+      'Unable to delete groups for user.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return group;
+};
+
+/**
+ * Updates a Portfolio group based on the passed data.
+ * @param id Portfolio Group ID
+ * @param data Updated `PortfolioGroup` details
+ * @returns updated `PortfolioGroup` document
+ * @throws `ApiError` if groups do not exist or could not be updated
+ */
+const updatePortfolioGroup = async (
+  id: string | Types.ObjectId,
+  data: Partial<PortfolioGroup>
+) => {
+  const updatedGroup = await PortfolioGroupSchema.findOneAndUpdate(
+    { id },
+    data,
+    { new: true }
+  );
+
+  if (!updatedGroup) {
+    throw new ApiError(
+      'Group could not be updated.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return updatedGroup;
+};
+
+/**
+ * Adds group relations for the provided portfolios
+ * @param groupId Portfolio Group ID
+ * @param portfolioIds IDs of the portfolios to add to the group
+ */
+const addPortfoliosToGroup = async (
+  groupId: string | Types.ObjectId,
+  portfolioIds: (string | Types.ObjectId)[]
+) => {
+  const portfolioIdToGroupRelation = (
+    id: string | Types.ObjectId
+  ): PortfolioGroupRelation => ({
+    portfolioId: id,
+    portfolioGroupId: groupId,
+  });
+  const relations = portfolioIds.map(portfolioIdToGroupRelation);
+  const relationDocs = await PortfolioGroupRelationSchema.create(relations);
+
+  if (!relationDocs) {
+    throw new ApiError(
+      'Portfolios could not be added to group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return relationDocs;
+};
+
+/**
+ * Removes group relations for the provided portfolios
+ * @param groupId Portfolio Group ID
+ * @param portfolioIds IDs of the portfolios to remove from the group
+ */
+const removePortfoliosFromGroup = async (
+  groupId: string | Types.ObjectId,
+  portfolioIds: (string | Types.ObjectId)[]
+) => {
+  const relationDocs = await PortfolioGroupRelationSchema.deleteMany({
+    portfolioGroupId: groupId,
+    portfolioId: { $in: portfolioIds },
+  });
+
+  if (!relationDocs) {
+    throw new ApiError(
+      'Portfolios could not be removed from group.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return relationDocs;
+};
+
+export default module.exports = {
+  createPortfolioGroup,
+  deletePortfolioGroup,
+  updatePortfolioGroup,
+  getPortfolioGroup,
+  addPortfoliosToGroup,
+  removePortfoliosFromGroup,
+};

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -48,7 +48,7 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
 };
 
 /**
- * Deletes a portfolio group from the database
+ * Deletes a portfolio group from the database and it's relations
  * @param id Portfolio Group ID
  * @returns Removed group data
  * @throws `ApiError` if group could not be deleted

--- a/apps/augury-backend/src/models/auth/PortfolioModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioModel.ts
@@ -1,0 +1,101 @@
+import PortfolioSchema from '../../config/schemas/PortfolioSchema';
+import ApiError from '../../errors/ApiError';
+import StatusCode from '../../config/enums/StatusCode';
+import Severity from '../../config/enums/Severity';
+import Portfolio from '../../config/interfaces/Portfolio';
+import DocumentId from '../../config/interfaces/DocumentId';
+import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
+
+/**
+ * Retrieves a portfolio by id
+ * @param portfolioId Mongoose document id of the portfolio
+ * @returns a `Porfolio` document
+ * @throws `ApiError` if the portfolio could not be retrieved
+ */
+const getPortfolio = async (portfolioId: DocumentId) => {
+  const portfolio = await SchemaErrorHandler(
+    PortfolioSchema.findById(portfolioId)
+  );
+
+  if (!portfolio) {
+    throw new ApiError(
+      'Unable to find portfolio',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return portfolio;
+};
+
+/**
+ * Creates a portfolio based on the passed data
+ * @param data `Portfolio` object
+ * @returns new `Portfolio` document
+ * @throws `ApiError` if the portfolio could not be created
+ */
+const createPortfolio = async (data: Portfolio) => {
+  const portfolio = await SchemaErrorHandler(PortfolioSchema.create(data));
+  if (!portfolio) {
+    throw new ApiError(
+      'Portfolio could not be created.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return portfolio;
+};
+
+/**
+ * Updates a portfolio based on the passed data.
+ * @param data Updated `Portfolio` object
+ * @returns updated `Portfolio` document
+ * @throws `ApiError` if the portfolio does not exist or could not be updated
+ */
+const updatePortfolio = async (data: Partial<Portfolio>) => {
+  const { id, ...updateData }: Partial<Portfolio> = data;
+
+  const updatedPortfolio = await SchemaErrorHandler(
+    PortfolioSchema.findByIdAndUpdate(id, updateData)
+  );
+
+  if (!updatedPortfolio) {
+    throw new ApiError(
+      'Portfolio could not be updated.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return updatedPortfolio;
+};
+
+/**
+ * Deletes a portfolio from the database
+ * @param portfolioId Mongoose document id of the portfolio
+ * @returns Removed portfolio data
+ * @throws `ApiError` if portfolio could not be deleted
+ */
+const deletePortfolio = async (portfolioId: DocumentId) => {
+  const portfolio = await SchemaErrorHandler(
+    PortfolioSchema.findByIdAndDelete(portfolioId)
+  );
+
+  if (!portfolio) {
+    throw new ApiError(
+      'Unable to delete portfolio.',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+
+  return portfolio;
+};
+
+export default module.exports = {
+  getPortfolio,
+  createPortfolio,
+  updatePortfolio,
+  deletePortfolio,
+};

--- a/apps/augury-backend/src/models/auth/PortfolioModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioModel.ts
@@ -57,7 +57,7 @@ const updatePortfolio = async (data: Partial<Portfolio>) => {
   const { id, ...updateData }: Partial<Portfolio> = data;
 
   const updatedPortfolio = await SchemaErrorHandler(
-    PortfolioSchema.findByIdAndUpdate(id, updateData)
+    PortfolioSchema.findByIdAndUpdate(id, updateData, { new: true })
   );
 
   if (!updatedPortfolio) {

--- a/apps/augury-backend/src/models/auth/SessionModel.ts
+++ b/apps/augury-backend/src/models/auth/SessionModel.ts
@@ -4,6 +4,7 @@ import StatusCode from '../../config/enums/StatusCode';
 import Session from '../../config/interfaces/Session';
 import SessionSchema from '../../config/schemas/SessionSchema';
 import ApiError from '../../errors/ApiError';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a `Session` based on the passed `userId`
@@ -11,7 +12,7 @@ import ApiError from '../../errors/ApiError';
  * @returns `Session` document
  * @throws ApiError if the session does not exist
  */
-const getSessionByUserId = async (userId: mongoose.Types.ObjectId | string) => {
+const getSessionByUserId = async (userId: DocumentId) => {
   const id = new mongoose.Types.ObjectId(userId);
   const session = await SessionSchema.findOne({ userId: id });
 

--- a/apps/augury-backend/src/models/auth/SessionModel.ts
+++ b/apps/augury-backend/src/models/auth/SessionModel.ts
@@ -1,10 +1,10 @@
-import mongoose from 'mongoose';
 import Severity from '../../config/enums/Severity';
 import StatusCode from '../../config/enums/StatusCode';
 import Session from '../../config/interfaces/Session';
 import SessionSchema from '../../config/schemas/SessionSchema';
 import ApiError from '../../errors/ApiError';
 import DocumentId from '../../config/interfaces/DocumentId';
+import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
 
 /**
  * Retrieves a `Session` based on the passed `userId`
@@ -13,8 +13,7 @@ import DocumentId from '../../config/interfaces/DocumentId';
  * @throws ApiError if the session does not exist
  */
 const getSessionByUserId = async (userId: DocumentId) => {
-  const id = new mongoose.Types.ObjectId(userId);
-  const session = await SessionSchema.findOne({ userId: id });
+  const session = await SchemaErrorHandler(SessionSchema.findOne({ userId }));
 
   if (!session) {
     throw new ApiError(
@@ -34,7 +33,9 @@ const getSessionByUserId = async (userId: DocumentId) => {
  * @throws ApiError if the session does not exist
  */
 const getSessionByToken = async (token: string) => {
-  const session = await SessionSchema.findOne({ token: token });
+  const session = await SchemaErrorHandler(
+    SessionSchema.findOne({ token: token })
+  );
 
   if (!session) {
     throw new ApiError(
@@ -54,7 +55,7 @@ const getSessionByToken = async (token: string) => {
  * @throws ApiError if session could not be created
  */
 const createSession = async (data: Session) => {
-  const session = await SessionSchema.create(data);
+  const session = await SchemaErrorHandler(SessionSchema.create(data));
 
   if (!session) {
     throw new ApiError(
@@ -75,7 +76,7 @@ const createSession = async (data: Session) => {
  */
 const updateSession = async (data: Session) => {
   const { userId, token }: Session = data;
-  const session = await SessionSchema.findOne({ userId: userId });
+  const session = await SchemaErrorHandler(SessionSchema.findOne({ userId }));
 
   if (!session) {
     throw new ApiError(

--- a/apps/augury-backend/src/models/auth/UserModel.ts
+++ b/apps/augury-backend/src/models/auth/UserModel.ts
@@ -1,10 +1,10 @@
-import mongoose from 'mongoose';
 import User from '../../config/interfaces/User';
 import UserSchema from '../../config/schemas/UserSchema';
 import ApiError from '../../errors/ApiError';
 import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import SessionController from '../../controllers/auth/SessionController';
+import DocumentId from '../../config/interfaces/DocumentId';
 
 /**
  * Retrieves a `User` based on passed id
@@ -12,7 +12,7 @@ import SessionController from '../../controllers/auth/SessionController';
  * @returns `User` document
  * @throws ApiError if user doesn't exists/invalid ID
  */
-const getUser = async (id: string | mongoose.Types.ObjectId) => {
+const getUser = async (id: DocumentId) => {
   const user = await UserSchema.findById(id);
 
   if (!user) {
@@ -73,10 +73,7 @@ const createUser = async (data: User) => {
  * @returns Updated user data
  * @throws ApiError if user doesn't exist/invalid id, or user couldn't be updated
  */
-const updateUser = async (
-  id: string | mongoose.Types.ObjectId,
-  data: Partial<User>
-) => {
+const updateUser = async (id: DocumentId, data: Partial<User>) => {
   const user = await UserSchema.findById(id);
 
   if (!user) {
@@ -116,7 +113,7 @@ const updateUser = async (
  * @param id Mongoose document id
  * @returns Removed user data
  */
-const deleteUser = async (id: string | mongoose.Types.ObjectId) => {
+const deleteUser = async (id: DocumentId) => {
   const user = await UserSchema.findByIdAndDelete(id);
 
   if (!user) {

--- a/apps/augury-backend/src/models/auth/UserModel.ts
+++ b/apps/augury-backend/src/models/auth/UserModel.ts
@@ -5,6 +5,7 @@ import StatusCode from '../../config/enums/StatusCode';
 import Severity from '../../config/enums/Severity';
 import SessionController from '../../controllers/auth/SessionController';
 import DocumentId from '../../config/interfaces/DocumentId';
+import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
 
 /**
  * Retrieves a `User` based on passed id
@@ -13,7 +14,7 @@ import DocumentId from '../../config/interfaces/DocumentId';
  * @throws ApiError if user doesn't exists/invalid ID
  */
 const getUser = async (id: DocumentId) => {
-  const user = await UserSchema.findById(id);
+  const user = await SchemaErrorHandler(UserSchema.findById(id));
 
   if (!user) {
     throw new ApiError(
@@ -33,7 +34,9 @@ const getUser = async (id: DocumentId) => {
  * @throws ApiError if user doesn't exists/invalid ID
  */
 const getUserByGoogleId = async (googleId: string) => {
-  const user = await UserSchema.findOne({ googleId: googleId });
+  const user = await SchemaErrorHandler(
+    UserSchema.findOne({ googleId: googleId })
+  );
 
   if (!user) {
     throw new ApiError(
@@ -53,7 +56,7 @@ const getUserByGoogleId = async (googleId: string) => {
  * @throws ApiError if user couldn't be created
  */
 const createUser = async (data: User) => {
-  const user = await UserSchema.create(data);
+  const user = await SchemaErrorHandler(UserSchema.create(data));
 
   if (!user) {
     throw new ApiError(
@@ -74,7 +77,7 @@ const createUser = async (data: User) => {
  * @throws ApiError if user doesn't exist/invalid id, or user couldn't be updated
  */
 const updateUser = async (id: DocumentId, data: Partial<User>) => {
-  const user = await UserSchema.findById(id);
+  const user = await SchemaErrorHandler(UserSchema.findById(id));
 
   if (!user) {
     throw new ApiError(
@@ -114,7 +117,7 @@ const updateUser = async (id: DocumentId, data: Partial<User>) => {
  * @returns Removed user data
  */
 const deleteUser = async (id: DocumentId) => {
-  const user = await UserSchema.findByIdAndDelete(id);
+  const user = await SchemaErrorHandler(UserSchema.findByIdAndDelete(id));
 
   if (!user) {
     throw new ApiError(

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -26,6 +26,7 @@ portfolioRouter
 portfolioRouter
   .route('/group')
   .post(asyncErrorHandler(PortfolioGroupController.createPortfolioGroup))
+  .put(asyncErrorHandler(PortfolioGroupController.updatePortfolioGroup))
   .delete(asyncErrorHandler(PortfolioGroupController.deletePortfolioGroup));
 
 portfolioRouter

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -36,4 +36,8 @@ portfolioRouter
     asyncErrorHandler(PortfolioGroupController.removePortfoliosFromGroup)
   );
 
+portfolioRouter
+  .route('/group/user/:id')
+  .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroupsByUserId));
+
 export default portfolioRouter;

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -2,12 +2,14 @@ import express, { Router } from 'express';
 // import { verifyAccessToken } from '../middlewares/AttachUserHandler';
 import asyncErrorHandler from '../middlewares/AsyncErrorHandler';
 import PortfolioDefaultController from '../controllers/auth/PortfolioDefaultController';
+import PortfolioGroupController from '../controllers/auth/PortfolioGroupController';
 
 const portfolioRouter: Router = express.Router();
 
 // Uncomment if we want to verify the client's auth token for all routes
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
 
+// ================ Portfolio Defaults ================
 portfolioRouter
   .route('/defaults')
   .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults));
@@ -19,4 +21,19 @@ portfolioRouter
   .delete(
     asyncErrorHandler(PortfolioDefaultController.deletePortfolioDefaults)
   );
+
+// ================ Portfolio Groups ================
+portfolioRouter
+  .route('/group')
+  .post(asyncErrorHandler(PortfolioGroupController.createPortfolioGroup))
+  .delete(asyncErrorHandler(PortfolioGroupController.deletePortfolioGroup));
+
+portfolioRouter
+  .route('/group/:id')
+  .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroup))
+  .put(asyncErrorHandler(PortfolioGroupController.addPortfoliosToGroup))
+  .delete(
+    asyncErrorHandler(PortfolioGroupController.removePortfoliosFromGroup)
+  );
+
 export default portfolioRouter;

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -3,11 +3,23 @@ import express, { Router } from 'express';
 import asyncErrorHandler from '../middlewares/AsyncErrorHandler';
 import PortfolioDefaultController from '../controllers/auth/PortfolioDefaultController';
 import PortfolioGroupController from '../controllers/auth/PortfolioGroupController';
+import PortfolioController from '../controllers/auth/PortfolioController';
 
 const portfolioRouter: Router = express.Router();
 
 // Uncomment if we want to verify the client's auth token for all routes
 // userRouter.use(asyncErrorHandler(verifyAccessToken));
+
+// ================ Portfolio Defaults ================
+portfolioRouter
+  .route('/')
+  .post(asyncErrorHandler(PortfolioController.createPortfolio));
+
+portfolioRouter
+  .route('/:id')
+  .get(asyncErrorHandler(PortfolioController.getPortfolio))
+  .put(asyncErrorHandler(PortfolioController.updatePortfolio))
+  .delete(asyncErrorHandler(PortfolioController.deletePortfolio));
 
 // ================ Portfolio Defaults ================
 portfolioRouter


### PR DESCRIPTION
This implements the basic functionality of the Portfolios. This does not do anything extra in terms of Portfolio or Group functionality as of yet (e.g. Does not retrieve extra BuyRecord data or the portfolio balance yet)

# Pre-requisites
- [ ] #87 
- [ ] #88 

# Changes Made
- Created `PortfolioModel`, `PortfolioController`, and added routes to `PortfolioRoutes`
- Added CRUD functionality for Portfolios.
  - POST `/portfolio` to create new Portfolio
  - GET `/portfolio/:id` to fetch a Portfolio
  - PUT `/portfolio/:id` to update a Portfolio
  - DELETE `/portfolio/:id` to delete a Portfolio
- Added new Validation function to validate Risk composition (e.g. should exist and add to 100).
- Made `riskPercentage1` and `riskPercentage2` required fields in database schema
- Also fixes issue where `ApiError`s were logged in console twice.