### PR TITLE
Add Logout Route to Backend

### DIFF
--- a/apps/augury-backend/src/main.ts
+++ b/apps/augury-backend/src/main.ts
@@ -15,6 +15,7 @@ import googleOauthHandler from './middlewares/GoogleOAuthHandler';
 // Routers
 import userRouter from './routes/UserRoutes';
 import portfolioRouter from './routes/PortfolioRoutes';
+import SessionController from './controllers/auth/SessionController';
 
 const app = express();
 
@@ -43,6 +44,7 @@ app.get('/google/callback', asyncErrorHandler(googleOauthHandler)); // Google Ca
 app.get('/ping', (req, res) => {
   res.send({ message: '[augury-backend] Pong!' });
 });
+app.post('/logout', asyncErrorHandler(SessionController.endSession));
 
 const server = app.listen(SERVER_PORT, () => {
   mongoose.set('strictQuery', false);

--- a/apps/augury-backend/src/models/auth/SessionModel.ts
+++ b/apps/augury-backend/src/models/auth/SessionModel.ts
@@ -101,9 +101,30 @@ const updateSession = async (data: Session) => {
   return updatedSession;
 };
 
+/**
+ * Deletes a Session from the database by token
+ * @param token Decoded access token
+ * @returns Deleted session data
+ * @throws `ApiError` if unable to delete the session
+ */
+const deleteSessionByToken = async (token: string) => {
+  const session = await SchemaErrorHandler(
+    SessionSchema.findOneAndDelete({ token })
+  );
+  if (!session) {
+    throw new ApiError(
+      'Could not delete session!',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  return session;
+};
+
 export default module.exports = {
   getSessionByUserId,
   getSessionByToken,
   createSession,
   updateSession,
+  deleteSessionByToken,
 };

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -12,17 +12,6 @@ const portfolioRouter: Router = express.Router();
 
 // ================ Portfolio Defaults ================
 portfolioRouter
-  .route('/')
-  .post(asyncErrorHandler(PortfolioController.createPortfolio));
-
-portfolioRouter
-  .route('/:id')
-  .get(asyncErrorHandler(PortfolioController.getPortfolio))
-  .put(asyncErrorHandler(PortfolioController.updatePortfolio))
-  .delete(asyncErrorHandler(PortfolioController.deletePortfolio));
-
-// ================ Portfolio Defaults ================
-portfolioRouter
   .route('/defaults')
   .post(asyncErrorHandler(PortfolioDefaultController.createPortfolioDefaults));
 
@@ -52,5 +41,16 @@ portfolioRouter
 portfolioRouter
   .route('/group/user/:id')
   .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroupsByUserId));
+
+// ================ Individual Portfolios ================
+portfolioRouter
+  .route('/')
+  .post(asyncErrorHandler(PortfolioController.createPortfolio));
+
+portfolioRouter
+  .route('/:id')
+  .get(asyncErrorHandler(PortfolioController.getPortfolio))
+  .put(asyncErrorHandler(PortfolioController.updatePortfolio))
+  .delete(asyncErrorHandler(PortfolioController.deletePortfolio));
 
 export default portfolioRouter;

--- a/apps/augury-backend/src/routes/UserRoutes.ts
+++ b/apps/augury-backend/src/routes/UserRoutes.ts
@@ -11,6 +11,14 @@ const userRouter: Router = express.Router();
 userRouter.route('/').post(asyncErrorHandler(UserController.createUser));
 
 userRouter
+  .route('/current')
+  .get(asyncErrorHandler(UserController.getLoggedInUserData));
+
+userRouter
+  .route('/onboard')
+  .post(asyncErrorHandler(UserController.onboardNewUser));
+
+userRouter
   .route('/:id')
   .get(asyncErrorHandler(UserController.getUser))
   .put(asyncErrorHandler(UserController.updateUser));
@@ -19,13 +27,5 @@ userRouter
 userRouter
   .route('/:id/balance')
   .put(asyncErrorHandler(UserController.updateUserBalance));
-
-userRouter
-  .route('/current')
-  .get(asyncErrorHandler(UserController.getLoggedInUserData));
-
-userRouter
-  .route('/onboard')
-  .post(asyncErrorHandler(UserController.onboardNewUser));
 
 export default userRouter;


### PR DESCRIPTION
# Description
Adds `/logout` route to API on backend. The endpoint destroys/deletes the currently logged in users' session and are expected to login again.

# Changes
- Adds `/logout`
- Adds endSession/deleteSession functionality to controller and model
- Reordered route declarations to prevent route collisions (e.g. Previous ordering after refactoring to use URL params meant we could not access `/user/current` as the `/user/:id` handler was defined first)

# Testing Steps
1. Go through the login flow and obtain an accessToken cookie
2. Make a GET request to `/user/current` and see you can access a protected route
3. Make the POST request to `/logout`; should return 200 OK
4. Make another GET request to `/user/current` and see the 403 forbidden error

# Follow-up
Front-end is expected to treat the 200 OK as a sign to redirect back to the login page.