### PR TITLE
Add Portfolio Valuation logic

### DIFF
--- a/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
+++ b/apps/augury-backend/src/config/interfaces/PortfolioGroup.ts
@@ -14,6 +14,7 @@ export type PortfolioGroupRequestBody = PortfolioGroup & {
 
 export type PortfolioGroupResponse = {
   group: PortfolioGroup;
+  portfolios?: DocumentId[];
 };
 
 export type PortfolioGroupsResponse = {

--- a/apps/augury-backend/src/config/interfaces/Stock.ts
+++ b/apps/augury-backend/src/config/interfaces/Stock.ts
@@ -7,6 +7,7 @@ export default interface Stock extends Identifiable {
 }
 
 export interface StockRequestBody {
+  userId: string;
   symbol: string;
   shares: number;
 }

--- a/apps/augury-backend/src/config/interfaces/Valuation.ts
+++ b/apps/augury-backend/src/config/interfaces/Valuation.ts
@@ -1,0 +1,13 @@
+import DocumentId from './DocumentId';
+
+export interface StockValuation {
+  stockId: DocumentId;
+  symbol: string;
+  totalValue: number;
+  totalShares: number;
+}
+
+export interface ValuationResult {
+  _id: DocumentId;
+  stocks: StockValuation[];
+}

--- a/apps/augury-backend/src/config/utils/TradeApi.ts
+++ b/apps/augury-backend/src/config/utils/TradeApi.ts
@@ -45,6 +45,29 @@ class TradeApi {
         }
       });
   }
+
+  public getQuotes(symbol: string[]): Promise<Map<string, AlpacaQuote>> {
+    return this.alpaca
+      .getLatestQuotes(symbol)
+      .then((quotes: Map<string, AlpacaQuote>) => {
+        return quotes;
+      })
+      .catch((err: unknown) => {
+        // May potentially 404 when invalid symbol is provided, but DB symbols should already be valid stocks.
+        if (err instanceof Error && err.message.startsWith('code: 404')) {
+          throw new ClientError(
+            'Invalid Stock symbol provided',
+            StatusCode.BAD_REQUEST
+          );
+        } else {
+          throw new ApiError(
+            'Unable to retrieve stock quote',
+            StatusCode.INTERNAL_ERROR,
+            Severity.MED
+          );
+        }
+      });
+  }
 }
 
 export default TradeApi;

--- a/apps/augury-backend/src/controllers/auth/StockController.ts
+++ b/apps/augury-backend/src/controllers/auth/StockController.ts
@@ -11,6 +11,12 @@ import {
 } from '../../config/utils/validation';
 import StockModel from '../../models/auth/StockModel';
 import TradeApi from '../../config/utils/TradeApi';
+import {
+  StockValuation,
+  ValuationResult,
+} from '../../config/interfaces/Valuation';
+
+const alpaca = TradeApi.getInstance();
 
 const buyStock = async (
   req: Request<Identifiable, unknown, StockRequestBody>,
@@ -24,7 +30,7 @@ const buyStock = async (
   assertNumber(shares, 'Invalid number provided');
   assertTrue(shares > 0, 'Must buy positive number of shares');
   // Get the current stock price from
-  const quoteData = await TradeApi.getInstance().getQuote(symbol);
+  const quoteData = await alpaca.getQuote(symbol);
   const price = quoteData.BidPrice;
   // Create a buy record for the requested stock
   const buyRecord = await StockModel.createBuyRecord(
@@ -63,7 +69,7 @@ const sellStock = async (
     'Cannot sell more shares than currently holding'
   );
   // Get the current stock price from
-  const quoteData = await TradeApi.getInstance().getQuote(symbol);
+  const quoteData = await alpaca.getQuote(symbol);
   const price = quoteData.AskPrice;
   // Create a buy record for the requested stock
   const buyRecord = await StockModel.createBuyRecord(
@@ -84,7 +90,126 @@ const sellStock = async (
   res.status(StatusCode.OK).send({ stock: buyRecord });
 };
 
+/**
+ * Gets the total price difference for a portfolios valuation as well as all the
+ * price differences for each stock symbol within a portfolio.
+ * @param req Incoming request with ID url parameter
+ * @param res Response with `totalPriceDifference` and the `symbolPriceDifferences`
+ * @throws `ApiError` if portfolio could not be valuated
+ */
+const calculatePortfolioValuation = async (
+  req: Request<Identifiable>,
+  res: Response
+) => {
+  const { id: portfolioId } = req.params;
+  // Assert the request format was valid
+  assertExists(portfolioId, 'Invalid portfolio ID provided');
+  // Get portfolios valuation
+  const valuation = await StockModel.calculatePortfolioValuation(portfolioId);
+  if (!valuation) {
+    throw new ApiError(
+      'Could not valuate this portfolio',
+      StatusCode.BAD_REQUEST,
+      Severity.MED
+    );
+  }
+  // Call helper function
+  const { totalPriceDifference, symbolPriceDifferences } =
+    await _calculatePortfolioValuation(valuation);
+
+  res
+    .status(StatusCode.OK)
+    .send({ totalPriceDifference, symbolPriceDifferences });
+};
+
+/**
+ * Gets the total price difference for a portfolios valuation as well as all the
+ * price differences for each stock symbol within a portfolio.
+ * @param req Incoming request with ID url parameter
+ * @param res Response with `totalPriceDifference` and each portfolio's id & their `totalPriceDifference`
+ * @throws `ApiError` if portfolio group could not be valuated
+ */
+const calculatePortfolioGroupValuation = async (
+  req: Request<Identifiable>,
+  res: Response
+) => {
+  const { id: portfolioGroupId } = req.params;
+  // Assert the request format was valid
+  assertExists(portfolioGroupId, 'Invalid portfolio group ID provided');
+  // Get portfolios valuation
+  const valuations = await StockModel.calculatePortfolioGroupValuation(
+    portfolioGroupId
+  );
+  if (!valuations) {
+    throw new ApiError(
+      'Could not valuate this portfolio',
+      StatusCode.BAD_REQUEST,
+      Severity.MED
+    );
+  }
+
+  const promises = valuations.map(async (valuation) => {
+    const { totalPriceDifference } = await _calculatePortfolioValuation(
+      valuation
+    );
+    return {
+      portfolioId: valuation._id,
+      totalPriceDifference,
+    };
+  });
+  // Await all valuation calls
+  const portfolioPriceDifferences = await Promise.all(promises);
+  const totalPriceDifference = portfolioPriceDifferences.reduce(
+    (total, currentPriceDiff) => {
+      return total + currentPriceDiff.totalPriceDifference;
+    },
+    0
+  );
+
+  res
+    .status(StatusCode.OK)
+    .send({ totalPriceDifference, portfolioPriceDifferences });
+};
+
+/**
+ * Helper function that calculates the actual current valuation of a portfolio
+ * @param valuation Result from Alpaca
+ * @returns Object with total price difference values and stock symbol price differences
+ */
+const _calculatePortfolioValuation = async (valuation: ValuationResult) => {
+  // Reduce valuation to get all symbols
+  const symbols: string[] = valuation.stocks.map(
+    (stock: StockValuation) => stock.symbol
+  );
+  // Call Alpaca API with symbols
+  const quotes = await alpaca.getQuotes(symbols);
+  // Calculate based on remaining shares in valuation the current price
+  const symbolPriceDifferences = valuation.stocks.map(
+    (stock: StockValuation) => {
+      // Get current asking bid price and multiply by the total shares currently held
+      const currentShareValue =
+        quotes.get(stock.symbol).BidPrice * stock.totalShares;
+      return {
+        symbol: stock.symbol,
+        priceDifference: currentShareValue - stock.totalValue, // Total Value already accounts for sold stock
+      };
+    }
+  );
+  // Calculate the total price difference of all stocks within this portfolio
+  const totalPriceDifference = symbolPriceDifferences.reduce(
+    (total: number, symbolPrice) => {
+      const { priceDifference } = symbolPrice;
+      return total + priceDifference;
+    },
+    0
+  );
+  // Return price values
+  return { totalPriceDifference, symbolPriceDifferences };
+};
+
 export default module.exports = {
   buyStock,
   sellStock,
+  calculatePortfolioValuation,
+  calculatePortfolioGroupValuation,
 };

--- a/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
+++ b/apps/augury-backend/src/models/auth/PortfolioGroupModel.ts
@@ -11,12 +11,11 @@ import SchemaErrorHandler from '../../middlewares/SchemaErrorHandler';
 /**
  * Retrieves a portfolio group by id
  * @param id Portfolio Group ID
- * @returns `PorfolioGroup` document
+ * @returns `PorfolioGroup` document & portfolio ids
  * @throws `ApiError` if group could not be retrieved
  */
 const getPortfolioGroup = async (id: DocumentId) => {
   const group = await SchemaErrorHandler(PortfolioGroupSchema.findById(id));
-
   if (!group) {
     throw new ApiError(
       'Unable to find group.',
@@ -24,17 +23,32 @@ const getPortfolioGroup = async (id: DocumentId) => {
       Severity.MED
     );
   }
-
-  return group;
+  const relations = await SchemaErrorHandler(
+    PortfolioGroupRelationSchema.find({ portfolioGroupId: group.id })
+  );
+  if (relations == undefined || relations == null) {
+    throw new ApiError(
+      'Unable to retrieve group relations',
+      StatusCode.INTERNAL_ERROR,
+      Severity.MED
+    );
+  }
+  const portfolios = relations.map((relation: PortfolioGroupRelation) => {
+    return relation.portfolioId;
+  });
+  return { group, portfolios };
 };
 
 /**
  * Creates a portfolio group based on the passed data
  * @param groupData `PortfolioGroup` object
- * @returns new `PortfolioGroup` document
+ * @returns new `PortfolioGroup` document & portfolio ids
  * @throws `ApiError` if group could not be created
  */
-const createPortfolioGroup = async (groupData: PortfolioGroup) => {
+const createPortfolioGroup = async (
+  groupData: PortfolioGroup,
+  portfolios: DocumentId[]
+) => {
   const group = await SchemaErrorHandler(
     PortfolioGroupSchema.create(groupData)
   );
@@ -47,13 +61,30 @@ const createPortfolioGroup = async (groupData: PortfolioGroup) => {
     );
   }
 
-  return group;
+  if (Array.isArray(portfolios) && portfolios.length > 0) {
+    const addPortfoliosResponse = await addPortfoliosToGroup(
+      group.id,
+      portfolios
+    );
+
+    // Throw error if somehow we errored on the server-side
+    if (!addPortfoliosResponse) {
+      throw new ApiError(
+        'Unable to add portfolios to group',
+        StatusCode.INTERNAL_ERROR,
+        Severity.MED
+      );
+    }
+
+    return addPortfoliosResponse;
+  }
+
+  return { group, portfolios: [] };
 };
 
 /**
  * Deletes a portfolio group from the database and it's relations
  * @param id Portfolio Group ID
- * @returns Removed group data
  * @throws `ApiError` if group could not be deleted
  */
 const deletePortfolioGroup = async (id: DocumentId) => {
@@ -75,15 +106,13 @@ const deletePortfolioGroup = async (id: DocumentId) => {
       Severity.MED
     );
   }
-
-  return group;
 };
 
 /**
  * Updates a Portfolio group based on the passed data.
  * @param id Portfolio Group ID
  * @param data Updated `PortfolioGroup` details
- * @returns updated `PortfolioGroup` document
+ * @returns updated `PortfolioGroup` document & portfolio ids
  * @throws `ApiError` if groups do not exist or could not be updated
  */
 const updatePortfolioGroup = async (
@@ -104,14 +133,14 @@ const updatePortfolioGroup = async (
     );
   }
 
-  return updatedGroup;
+  return await getPortfolioGroup(updatedGroup.id);
 };
 
 /**
  * Adds group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to add to the group
- * @returns Updated PortfolioGroup
+ * @returns Updated PortfolioGroup & portfolio ids
  */
 const addPortfoliosToGroup = async (
   groupId: DocumentId,
@@ -143,7 +172,7 @@ const addPortfoliosToGroup = async (
  * Removes group relations for the provided portfolios
  * @param groupId Portfolio Group ID
  * @param portfolioIds IDs of the portfolios to remove from the group
- * @returns Updated PortfolioGroup
+ * @returns Updated PortfolioGroup & portfolio ids
  */
 const removePortfoliosFromGroup = async (
   groupId: DocumentId,

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -40,6 +40,10 @@ portfolioRouter
   );
 
 portfolioRouter
+  .route('/group/:id/valuation')
+  .get(asyncErrorHandler(StockController.calculatePortfolioGroupValuation));
+
+portfolioRouter
   .route('/group/user/:id')
   .get(asyncErrorHandler(PortfolioGroupController.getPortfolioGroupsByUserId));
 
@@ -62,5 +66,9 @@ portfolioRouter
 portfolioRouter
   .route('/:id/sell')
   .post(asyncErrorHandler(StockController.sellStock));
+
+portfolioRouter
+  .route('/:id/valuation')
+  .get(asyncErrorHandler(StockController.calculatePortfolioValuation));
 
 export default portfolioRouter;


### PR DESCRIPTION
# Pre-requisites
- [x] #104 

# Description
This adds the two routes for portfolio valuation logic:
- GET 'portfolio/:id/valuation', returns the discussed total price difference & stock symbol price differences
- GET 'portfolio/group/:id/valuation', returns total group price difference & map of individual portfolio ids to their price differences.
- Uses aggregate logic (may be more complex but is enough for what we need)
- User balance updates now when calling `BuyStock` or `SellStock`