### PR TITLE
Create get all symbols route

### DIFF
--- a/apps/augury-backend/src/config/utils/TradeApi.ts
+++ b/apps/augury-backend/src/config/utils/TradeApi.ts
@@ -68,6 +68,28 @@ class TradeApi {
         }
       });
   }
+
+  public getAllSymbols(): string[] {
+    // Type required to extract symbol. Ref: https://docs.alpaca.markets/reference/get-v2-assets-1)
+    // For some reason, the Asset type exists within the README.md but not in the type defs
+    type Asset = { symbol: string; status: string; tradable: boolean };
+    return this.alpaca
+      .getAssets()
+      .then((assets: Asset[]) => {
+        const isValidAsset = (asset: Asset) => {
+          return asset.status == 'active' && asset.tradable;
+        };
+        // Return array of mapped symbol strings
+        return assets.filter(isValidAsset).map((asset) => asset.symbol);
+      })
+      .catch((err: unknown) => {
+        throw new ApiError(
+          'Unable to retrieve stock symbols',
+          StatusCode.INTERNAL_ERROR,
+          Severity.MED
+        );
+      });
+  }
 }
 
 export default TradeApi;

--- a/apps/augury-backend/src/controllers/auth/StockController.ts
+++ b/apps/augury-backend/src/controllers/auth/StockController.ts
@@ -223,9 +223,21 @@ const _calculatePortfolioValuation = async (valuation: ValuationResult) => {
   return { totalPriceDifference, symbolPriceDifferences };
 };
 
+/**
+ * Retrieves all stock symbols from Alpaca
+ * @param req Incoming request
+ * @param res Object with array of stock symbols
+ */
+const getAllSymbols = async (req: Request, res: Response) => {
+  // Possibly cache/memoize this in future
+  const symbols = await alpaca.getAllSymbols();
+  res.status(StatusCode.OK).send({ symbols });
+};
+
 export default module.exports = {
   buyStock,
   sellStock,
   calculatePortfolioValuation,
   calculatePortfolioGroupValuation,
+  getAllSymbols,
 };

--- a/apps/augury-backend/src/main.ts
+++ b/apps/augury-backend/src/main.ts
@@ -16,6 +16,7 @@ import googleOauthHandler from './middlewares/GoogleOAuthHandler';
 import userRouter from './routes/UserRoutes';
 import portfolioRouter from './routes/PortfolioRoutes';
 import SessionController from './controllers/auth/SessionController';
+import stockRouter from './routes/StockRoutes';
 
 const app = express();
 
@@ -38,6 +39,7 @@ app.use('/assets', express.static(path.join(__dirname, 'assets')));
 // Application routers that register handlers
 app.use('/user', userRouter);
 app.use('/portfolio', portfolioRouter);
+app.use('/stock', stockRouter);
 
 // API Routes
 app.get('/google/callback', asyncErrorHandler(googleOauthHandler)); // Google Callback route that is used after OAuth redirect

--- a/apps/augury-backend/src/routes/StockRoutes.ts
+++ b/apps/augury-backend/src/routes/StockRoutes.ts
@@ -1,0 +1,16 @@
+import express, { Router } from 'express';
+// import { verifyAccessToken } from '../middlewares/AttachUserHandler';
+import asyncErrorHandler from '../middlewares/AsyncErrorHandler';
+import StockController from '../controllers/auth/StockController';
+
+const stockRouter: Router = express.Router();
+
+// Uncomment if we want to verify the client's auth token for all routes
+// userRouter.use(asyncErrorHandler(verifyAccessToken));
+
+// ================ Stocks ================
+stockRouter
+  .route('/symbols')
+  .get(asyncErrorHandler(StockController.getAllSymbols));
+
+export default stockRouter;


### PR DESCRIPTION
# Pre-requisites

- [ ] #105 

# Description

This adds a single route to retrieve all valid stock symbols from the Alpaca trading API.
- Adds GET `/stock/symbols` which returns an Object containing an array of stock symbols