### PR TITLE
Create basic portfolio recommendation call to AI

### DIFF
--- a/apps/augury-backend/src/config/ai/AiApiInterface.ts
+++ b/apps/augury-backend/src/config/ai/AiApiInterface.ts
@@ -1,0 +1,5 @@
+abstract class AbstractAiApi {
+  abstract generateResponse(input: string): Promise<string>;
+}
+
+export default AbstractAiApi;

--- a/apps/augury-backend/src/config/ai/HuggingFaceInferenceApi.ts
+++ b/apps/augury-backend/src/config/ai/HuggingFaceInferenceApi.ts
@@ -1,0 +1,38 @@
+import { HfInference } from '@huggingface/inference';
+import AbstractAiApi from './AiApiInterface';
+
+class HuggingFaceInferenceApi implements AbstractAiApi {
+  static instance: HuggingFaceInferenceApi;
+  private client: HfInference;
+
+  private constructor() {
+    this.client = new HfInference(process.env.HUGGINGFACE_API_KEY);
+  }
+
+  public static getInstance() {
+    if (!HuggingFaceInferenceApi.instance) {
+      HuggingFaceInferenceApi.instance = new HuggingFaceInferenceApi();
+    }
+    return HuggingFaceInferenceApi.instance;
+  }
+
+  public generateResponse(input: string): Promise<string> {
+    // Taken from inference completion example, using Mixtral to give better responses
+    return this.client
+      .chatCompletion({
+        model: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
+        messages: [
+          {
+            role: 'user',
+            content: input.trim(),
+          },
+        ],
+        max_tokens: 500,
+      })
+      .then((chatCompletion) => {
+        return chatCompletion.choices[0].message.content;
+      });
+  }
+}
+
+export default HuggingFaceInferenceApi;

--- a/apps/augury-backend/src/config/ai/HuggingFaceInferenceApi.ts
+++ b/apps/augury-backend/src/config/ai/HuggingFaceInferenceApi.ts
@@ -2,18 +2,10 @@ import { HfInference } from '@huggingface/inference';
 import AbstractAiApi from './AiApiInterface';
 
 class HuggingFaceInferenceApi implements AbstractAiApi {
-  static instance: HuggingFaceInferenceApi;
   private client: HfInference;
 
-  private constructor() {
+  public constructor() {
     this.client = new HfInference(process.env.HUGGINGFACE_API_KEY);
-  }
-
-  public static getInstance() {
-    if (!HuggingFaceInferenceApi.instance) {
-      HuggingFaceInferenceApi.instance = new HuggingFaceInferenceApi();
-    }
-    return HuggingFaceInferenceApi.instance;
   }
 
   public generateResponse(input: string): Promise<string> {

--- a/apps/augury-backend/src/controllers/auth/StockController.ts
+++ b/apps/augury-backend/src/controllers/auth/StockController.ts
@@ -19,7 +19,7 @@ import UserModel from '../../models/auth/UserModel';
 import HuggingFaceInferenceApi from '../../config/ai/HuggingFaceInferenceApi';
 
 const alpaca = TradeApi.getInstance();
-const huggingface = HuggingFaceInferenceApi.getInstance();
+const huggingface = new HuggingFaceInferenceApi();
 
 const buyStock = async (
   req: Request<Identifiable, unknown, StockRequestBody>,
@@ -254,7 +254,7 @@ const getPortfolioRecommendation = async (
 
   // Generate a response
   const output = await huggingface.generateResponse(
-    `These are the current top performing stock options: ${topStockSymbols}. This portfolio is evaluated at ${totalPriceDifference}. Please recommend some ways or general advice on how to utilize these options! Please keep it to a maximum of three recommendations.`
+    `These are the current top performing stock options: ${topStockSymbols}. This portfolio is evaluated at ${totalPriceDifference}. Please recommend some ways or general advice on how to utilize these options! Please keep it to a maximum of three short recommendations.`
   );
 
   // console.log('Output: ' + output);

--- a/apps/augury-backend/src/routes/PortfolioRoutes.ts
+++ b/apps/augury-backend/src/routes/PortfolioRoutes.ts
@@ -71,4 +71,9 @@ portfolioRouter
   .route('/:id/valuation')
   .get(asyncErrorHandler(StockController.calculatePortfolioValuation));
 
+// ================ Portfolio AI Functionality ================
+portfolioRouter
+  .route('/:id/ai/recommendation')
+  .get(asyncErrorHandler(StockController.getPortfolioRecommendation));
+
 export default portfolioRouter;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@huggingface/inference": "^2.8.1",
     "axios": "^1.7.7",
     "chakra-multiselect": "^0.4.13",
     "compression": "^1.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@alpacahq/alpaca-trade-api':
+        specifier: ^3.1.2
+        version: 3.1.2
       '@catppuccin/palette':
         specifier: ^1.4.0
         version: 1.4.0
@@ -32,6 +35,9 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^0.2.2
         version: 0.2.2(@fortawesome/fontawesome-svg-core@6.6.0)(react@18.3.1)
+      '@huggingface/inference':
+        specifier: ^2.8.1
+        version: 2.8.1
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -251,6 +257,10 @@ packages:
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
+
+  '@alpacahq/alpaca-trade-api@3.1.2':
+    resolution: {integrity: sha512-TprXMD2rMrF1X0imQoP9NyC0UTZi4I7BctR1z7QfE2oRUp+DcPfIn2T55fBxYpmxSrP36PNJYsNVZS3/CNG/7w==}
+    engines: {node: '>=16.9', npm: '>=6'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1656,6 +1666,13 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
       react: '>=16.3'
 
+  '@huggingface/inference@2.8.1':
+    resolution: {integrity: sha512-EfsNtY9OR6JCNaUa5bZu2mrs48iqeTz0Gutwf+fU0Kypx33xFQB4DKMhp8u4Ee6qVbLbNWvTHuWwlppLQl4p4Q==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tasks@0.12.30':
+    resolution: {integrity: sha512-A1ITdxbEzx9L8wKR8pF7swyrTLxWNDFIGDLUWInxvks2ruQ8PLRBZe8r0EcjC3CDdtlj9jV1V4cgV35K/iy3GQ==}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -2934,6 +2951,9 @@ packages:
     resolution: {integrity: sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==}
     engines: {node: '>=4'}
 
+  axios@0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+
   axios@1.7.7:
     resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
 
@@ -3714,6 +3734,10 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
+  dotenv@6.2.0:
+    resolution: {integrity: sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==}
+    engines: {node: '>=6'}
+
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -4003,6 +4027,9 @@ packages:
   ext-name@5.0.0:
     resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
     engines: {node: '>=4'}
+
+  extend@2.0.2:
+    resolution: {integrity: sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4994,6 +5021,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  just-extend@4.2.1:
+    resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
+
   jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
 
@@ -5368,6 +5398,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpack5@5.3.2:
+    resolution: {integrity: sha512-e9jz+6InQIUb2cGzZ/Mi+rQBs1KFLby+gNi+22VwQ1pnC9ieZjysKGmRMjdlf6IyjsltbgY4tGoHwHmyS7l94A==}
+
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
@@ -5375,6 +5408,11 @@ packages:
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nats@1.4.12:
+    resolution: {integrity: sha512-Jf4qesEF0Ay0D4AMw3OZnKMRTQm+6oZ5q8/m4gpy5bTmiDiK6wCXbZpzEslmezGpE93LV3RojNEG6dpK/mysLQ==}
+    engines: {node: '>= 8.0.0'}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -5461,6 +5499,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nuid@1.1.6:
+    resolution: {integrity: sha512-Eb3CPCupYscP1/S1FQcO5nxtu6l/F3k0MQ69h7f5osnsemVk5pkc8/5AyalVT+NCfra9M71U8POqF6EZa6IHvg==}
+    engines: {node: '>= 8.16.0'}
 
   nwsapi@2.2.12:
     resolution: {integrity: sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==}
@@ -6814,6 +6856,9 @@ packages:
       typescript: '*'
       webpack: ^5.0.0
 
+  ts-nkeys@1.0.16:
+    resolution: {integrity: sha512-1qrhAlavbm36wtW+7NtKOgxpzl+70NTF8xlz9mEhiA5zHMlMxjj3sEVKWm3pGZhHXE0Q3ykjrj+OSRVaYw+Dqg==}
+
   ts-node@10.9.1:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -6848,6 +6893,9 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6965,6 +7013,9 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  urljoin@0.1.5:
+    resolution: {integrity: sha512-OSGi+PS3zxk8XfQ+7buaupOdrW9P9p+V9rjxGzJaYEYDe/B2rv3WJCupq5LNERW4w4kWxsduUUrhCxZZiQ2udw==}
 
   use-callback-ref@1.3.2:
     resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
@@ -7245,6 +7296,18 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
@@ -7317,6 +7380,25 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.0': {}
+
+  '@alpacahq/alpaca-trade-api@3.1.2':
+    dependencies:
+      axios: 0.21.4
+      dotenv: 6.2.0
+      eslint: 8.57.0
+      events: 3.3.0
+      just-extend: 4.2.1
+      lodash: 4.17.21
+      minimist: 1.2.8
+      msgpack5: 5.3.2
+      nats: 1.4.12
+      urljoin: 0.1.5
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -9128,6 +9210,12 @@ snapshots:
       '@fortawesome/fontawesome-svg-core': 6.6.0
       prop-types: 15.8.1
       react: 18.3.1
+
+  '@huggingface/inference@2.8.1':
+    dependencies:
+      '@huggingface/tasks': 0.12.30
+
+  '@huggingface/tasks@0.12.30': {}
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -11125,6 +11213,12 @@ snapshots:
 
   axe-core@4.10.0: {}
 
+  axios@0.21.4:
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.3.7)
+    transitivePeerDependencies:
+      - debug
+
   axios@1.7.7:
     dependencies:
       follow-redirects: 1.15.9(debug@4.3.7)
@@ -11976,6 +12070,8 @@ snapshots:
 
   dotenv@16.4.5: {}
 
+  dotenv@6.2.0: {}
+
   duplexer@0.1.2: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -12428,6 +12524,8 @@ snapshots:
     dependencies:
       ext-list: 2.2.2
       sort-keys-length: 1.0.1
+
+  extend@2.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -13674,6 +13772,8 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
+  just-extend@4.2.1: {}
+
   jwa@1.4.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -14037,12 +14137,24 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpack5@5.3.2:
+    dependencies:
+      bl: 4.1.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      safe-buffer: 5.2.1
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
   nanoid@3.3.7: {}
+
+  nats@1.4.12:
+    dependencies:
+      nuid: 1.1.6
+      ts-nkeys: 1.0.16
 
   natural-compare@1.4.0: {}
 
@@ -14130,6 +14242,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuid@1.1.6: {}
 
   nwsapi@2.2.12: {}
 
@@ -15530,6 +15644,10 @@ snapshots:
       typescript: 5.5.4
       webpack: 5.94.0(@swc/core@1.5.29(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
 
+  ts-nkeys@1.0.16:
+    dependencies:
+      tweetnacl: 1.0.3
+
   ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.13))(@types/node@18.16.9)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -15594,6 +15712,8 @@ snapshots:
   tslib@2.7.0: {}
 
   tsscmp@1.0.6: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:
@@ -15702,6 +15822,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  urljoin@0.1.5:
+    dependencies:
+      extend: 2.0.2
 
   use-callback-ref@1.3.2(@types/react@18.3.1)(react@18.3.1):
     dependencies:
@@ -16024,6 +16148,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@7.5.10: {}
 
   ws@8.17.1: {}
 


### PR DESCRIPTION
# Description
This implements and adds basic AI functionality to get recommendations based on our portfolio valuation. Since we do not have access to OpenAI at the moment, we made an abstract base that we can extend/implement if we want to switch to a different AI model or API.

# Changes
- Adds basic implementation of HuggingFace inference call (based on example code provided by HuggingFace)
  - Changed inference model to use Mixtral, as it appeared to actually provide some reasonable portfolio feedback
- Adds route to portfolios as GET `portfolio/:id/ai/recommendation`. ("ai/" subroute was chosen in case we wanted to expand further.
- Adds "@huggingface/inference" to package.json
- Adds `HUGGINGFACE_API_KEY` to `.env`